### PR TITLE
Add global GitHub icon link to docs navbar

### DIFF
--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -22,6 +22,10 @@ website:
         text: Architecture
       - href: talks/ts_agents_talk.qmd
         text: Talk
+    right:
+      - icon: github
+        href: https://github.com/fnauman/ts-agents
+        aria-label: GitHub repository
 
 format:
   html:


### PR DESCRIPTION
## Summary
- add a GitHub icon link to the Quarto docs navbar
- place it in `navbar.right` so it is visible from every docs page
- include `aria-label` for accessibility

## Validation
- quarto render docs

Closes #5