### PR TITLE
Harden docs deploy workflow trigger reliability

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,6 +3,16 @@ name: Deploy Docs
 on:
   push:
     branches: [main]
+    paths:
+      - "docs/**"
+      - ".github/workflows/docs.yml"
+  pull_request:
+    paths:
+      - "docs/**"
+      - ".github/workflows/docs.yml"
+  pull_request_target:
+    types: [closed]
+    branches: [main]
   workflow_dispatch:
 
 permissions:
@@ -16,9 +26,13 @@ concurrency:
 
 jobs:
   build:
+    if: github.event_name != 'pull_request_target' || github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          # For merged PR fallback deploys, build the exact merged commit.
+          ref: ${{ github.event.pull_request.merge_commit_sha || github.sha }}
 
       - uses: quarto-dev/quarto-actions/setup@v2
 
@@ -30,6 +44,7 @@ jobs:
           path: docs/_site
 
   deploy:
+    if: github.event_name != 'pull_request'
     needs: build
     runs-on: ubuntu-latest
     environment:


### PR DESCRIPTION
## Summary
- add docs workflow fallback trigger for merged PRs into main via pull_request_target (closed)
- keep push-to-main and manual docs deploy triggers
- add guards so unmerged PR closes do not build/deploy
- run docs render on pull_request for docs/workflow changes as an early check

## Why
Recent merged docs changes reached main without an automatic deploy run. This adds a second trigger path so merged PRs still deploy docs even if push-triggered runs are missed.

## Validation
- workflow YAML parse: pass
- quarto render docs: pass

Closes #7
