### PR TITLE
Improve onboarding docs and add hosted demo scaffold

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,89 @@
 # ts-agents
 
 [![Docs](https://img.shields.io/badge/docs-online-blue)](https://fnauman.github.io/ts-agents/)
+[![Python](https://img.shields.io/badge/python-3.11%2B-3776AB)](#installation)
+[![License](https://img.shields.io/badge/license-MIT-2EA44F)](LICENSE)
 
-ts-agents is a time-series analysis toolkit with:
-- a CLI-first workflow (`ts-agents`)
-- a Gradio app (`python main.py`)
-- tool-driven agent workflows (simple + deep)
+`ts-agents` is a CLI-first toolkit for time-series analysis and agent-driven
+automation. It combines:
+- a stable CLI contract for reproducible runs (`ts-agents`)
+- inspectable artifacts instead of chat-only outputs (plots, JSON, reports)
+- optional sandboxes for safer execution (`local`, `subprocess`, `docker`, `daytona`, `modal`)
+- both a Gradio UI (`python main.py`) and tool-driven agents (simple + deep)
 
 It ships with three out-of-the-box demos:
 - `window-classification` (synthetic labeled-stream window-size selection + evaluation)
 - `window-classification --csv-path data/wisdm_subset.csv` (WISDM real accelerometer data)
 - `forecasting` (baseline comparison and report artifacts)
 
+**Start here:** [Quickstart](#quickstart) | [Choose your path](#choose-your-path) | [Docs site](https://fnauman.github.io/ts-agents/) | [Demo walkthroughs](docs/walkthroughs.qmd) | [Hosted demo guide](docs/huggingface-spaces.qmd)
+
 ![ts-agents demo](demo/assets/demo.gif)
+
+## Table of Contents
+
+- [Choose your path](#choose-your-path)
+- [Why ts-agents instead of using statsforecast/sktime/aeon directly?](#why-ts-agents-instead-of-using-statsforecastsktimeaeon-directly)
+- [Design principles](#design-principles)
+- [Quickstart](#quickstart)
+- [Installation](#installation)
+- [CLI usage](#cli-usage)
+- [Gradio app](#gradio-app)
+- [Sandbox backends](#sandbox-backends)
+- [Guides](#guides)
+- [Development](#development)
+
+## Choose Your Path
+
+### 1. Run a deterministic demo in under a minute
+
+Use the scripted flows when you want a quick proof that the toolchain works,
+without requiring an LLM key.
+
+```bash
+uv sync
+uv run ts-agents demo window-classification --no-llm
+uv run ts-agents demo forecasting --no-llm
+```
+
+### 2. Use the CLI on bundled or custom data
+
+Use the CLI when you want reproducible commands, saved artifacts, and easy
+automation.
+
+```bash
+uv run ts-agents tool list --bundle demo
+uv run ts-agents run stl_decompose_with_data --run Re200Rm200 --var bx001_real
+uv run ts-agents demo window-classification --csv-path data/wisdm_subset.csv --no-llm
+```
+
+### 3. Launch the UI or prepare a hosted demo
+
+Use the Gradio app for interactive exploration, or the hosted entrypoint for a
+public manual-mode deployment.
+
+```bash
+uv run python main.py
+python app.py
+```
+
+For hosted deployment details, see [docs/huggingface-spaces.qmd](docs/huggingface-spaces.qmd).
+
+## Why ts-agents Instead of Using statsforecast/sktime/aeon Directly?
+
+Those libraries are excellent algorithm/toolkit layers, and `ts-agents`
+intentionally builds on that ecosystem rather than trying to replace it.
+
+Use the underlying libraries directly when:
+- you only need one modeling library inside a notebook or a custom pipeline
+- you do not need artifacts, tool routing, or sandboxed execution
+
+Use `ts-agents` when you want:
+- a stable CLI contract that works the same across demos, agents, and automation
+- artifact-first outputs (plots, JSON, markdown/report assets) instead of chat-only responses
+- reusable skills and tool bundles that encode workflow guidance
+- optional sandbox backends for isolation, deployment, and heavier workloads
+- swappable front ends: CLI, Gradio UI, or custom agent orchestration
 
 ## Design Principles
 
@@ -66,6 +137,15 @@ cd ts-agents
 uv sync
 ```
 
+Local editable install from a source checkout:
+
+```bash
+python -m pip install -e .
+```
+
+PyPI and prebuilt container publishing are planned, but source install is the
+supported path today.
+
 CLI entrypoints:
 - Preferred: `ts-agents ...`
 - Also supported: `python -m ts_agents ...`
@@ -85,6 +165,16 @@ All optional. Set them via `export` or in `~/.env`.
 
 Sandbox-specific environment variables (Docker/Daytona/Modal auth, snapshots,
 streaming, and log files) are documented in `SANDBOX.md`.
+
+### Hosted Demo Deployment
+
+The repo now includes a hosted Gradio entrypoint at `app.py` intended for
+public demos such as Hugging Face Spaces. It defaults to:
+- manual analysis mode (`agent` disabled)
+- no session persistence
+- a public-safe configuration that does not require `OPENAI_API_KEY`
+
+See [docs/huggingface-spaces.qmd](docs/huggingface-spaces.qmd) for deployment instructions and optional agent-mode configuration.
 
 ## CLI Usage
 

--- a/app.py
+++ b/app.py
@@ -1,0 +1,31 @@
+"""Hosted Gradio entrypoint for public deployments such as Hugging Face Spaces."""
+
+from __future__ import annotations
+
+import os
+
+from src.ui import create_app, launch_app
+
+
+def _env_flag(name: str, default: bool) -> bool:
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    return raw.strip().lower() in {"1", "true", "yes", "on"}
+
+
+app = create_app(
+    enable_agent=_env_flag("TS_AGENTS_ENABLE_AGENT", False),
+    agent_type=os.environ.get("TS_AGENTS_AGENT_TYPE", "simple"),
+    persist_sessions=_env_flag("TS_AGENTS_PERSIST_SESSIONS", False),
+    title=os.environ.get("TS_AGENTS_UI_TITLE", "ts-agents Demo"),
+)
+
+
+if __name__ == "__main__":
+    launch_app(
+        app,
+        share=_env_flag("GRADIO_SHARE", False),
+        server_name=os.environ.get("HOST", "0.0.0.0"),
+        server_port=int(os.environ.get("PORT", "7860")),
+    )

--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -14,6 +14,8 @@ website:
         text: CLI Examples
       - href: walkthroughs.qmd
         text: Walkthroughs
+      - href: huggingface-spaces.qmd
+        text: HF Spaces
       - href: skills-guide.qmd
         text: Skills Guide
       - href: philosophy.qmd

--- a/docs/huggingface-spaces.qmd
+++ b/docs/huggingface-spaces.qmd
@@ -1,0 +1,66 @@
+---
+title: "Hugging Face Spaces"
+---
+
+`ts-agents` now includes a root `app.py` entrypoint for hosted Gradio
+deployments such as Hugging Face Spaces.
+
+## Default Hosted Behavior
+
+The hosted entrypoint is intentionally conservative:
+
+- agent chat is disabled by default
+- session persistence is disabled by default
+- the app binds to `0.0.0.0:$PORT`
+- no `OPENAI_API_KEY` is required for manual analysis tabs
+
+This keeps the default public demo focused on safe, zero-secret manual analysis.
+
+## Quick Setup
+
+1. Create a new **Gradio** Space on Hugging Face.
+2. Upload this repo (or mirror the relevant files) so the Space sees:
+   - `app.py`
+   - `requirements.txt`
+   - `src/`
+   - `ts_agents/`
+   - `data/`
+3. Let Spaces install dependencies from `requirements.txt`.
+4. Launch the app. The default entrypoint is `app.py`.
+
+## Optional Environment Variables
+
+Use these Space variables if you want to change the defaults:
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `TS_AGENTS_ENABLE_AGENT` | `false` | Enable the agent chat tab |
+| `TS_AGENTS_AGENT_TYPE` | `simple` | Default agent type when agent tab is enabled |
+| `TS_AGENTS_PERSIST_SESSIONS` | `false` | Enable session persistence |
+| `TS_AGENTS_UI_TITLE` | `ts-agents Demo` | UI title override |
+| `OPENAI_API_KEY` | unset | Required only if hosted agent features should call OpenAI |
+
+## Recommended Public Demo Mode
+
+For an easy public demo:
+
+- keep `TS_AGENTS_ENABLE_AGENT=false`
+- keep persistence off
+- focus the walkthrough on decomposition, forecasting, patterns, and classification tabs
+
+Once that flow is stable, you can optionally add agent mode by setting
+`OPENAI_API_KEY` and `TS_AGENTS_ENABLE_AGENT=true`.
+
+## Local Smoke Test
+
+Before deploying, verify the hosted entrypoint locally:
+
+```bash
+python app.py
+```
+
+Or with agent mode enabled:
+
+```bash
+TS_AGENTS_ENABLE_AGENT=true OPENAI_API_KEY=your-key python app.py
+```

--- a/docs/index.qmd
+++ b/docs/index.qmd
@@ -12,6 +12,7 @@ without rewriting the core toolchain.
 - [Quickstart](quickstart.qmd): install and run your first command in under a minute
 - [CLI Examples](cli-examples.qmd): practical CLI patterns by example
 - [Walkthroughs](walkthroughs.qmd): step-by-step guides for the built-in demos
+- [Hugging Face Spaces](huggingface-spaces.qmd): deploy a public Gradio demo from the hosted `app.py` entrypoint
 - [Skills Guide](skills-guide.qmd): using, customizing, and creating skills
 - [Philosophy](philosophy.qmd): why the project is structured around a stable CLI contract
 - [Architecture](architecture.qmd): how tools, sandboxes, agents, and UI fit together

--- a/tests/test_hosted_app.py
+++ b/tests/test_hosted_app.py
@@ -1,0 +1,33 @@
+import importlib
+import sys
+
+import gradio as gr
+
+
+def test_hosted_app_exports_gradio_blocks(monkeypatch):
+    for name in [
+        "TS_AGENTS_ENABLE_AGENT",
+        "TS_AGENTS_AGENT_TYPE",
+        "TS_AGENTS_PERSIST_SESSIONS",
+        "TS_AGENTS_UI_TITLE",
+        "GRADIO_SHARE",
+        "HOST",
+        "PORT",
+    ]:
+        monkeypatch.delenv(name, raising=False)
+
+    sys.modules.pop("app", None)
+    module = importlib.import_module("app")
+
+    assert isinstance(module.app, gr.Blocks)
+
+
+def test_hosted_app_env_flag_helper(monkeypatch):
+    sys.modules.pop("app", None)
+    module = importlib.import_module("app")
+
+    monkeypatch.setenv("TS_AGENTS_ENABLE_AGENT", "true")
+    assert module._env_flag("TS_AGENTS_ENABLE_AGENT", False) is True
+
+    monkeypatch.setenv("TS_AGENTS_ENABLE_AGENT", "0")
+    assert module._env_flag("TS_AGENTS_ENABLE_AGENT", True) is False


### PR DESCRIPTION
## Summary
- refresh the README onboarding surface with clearer paths and positioning
- add a hosted `app.py` Gradio entrypoint for public demo deployments
- add Hugging Face Spaces deployment docs and link them into the docs nav
- add a focused smoke test for the hosted app entrypoint

## Testing
- `UV_CACHE_DIR=/tmp/uv-cache uv run python -m pytest -q tests/test_hosted_app.py`

Closes #9
