### PR TITLE
Add package and container publishing workflows

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+.git
+.github
+.pytest_cache
+.venv
+__pycache__
+*.pyc
+docs/_site
+outputs
+experiments
+dist
+build
+PLAN.md

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,3 +29,6 @@ jobs:
 
       - name: Run tests
         run: uv run python -m pytest -q
+
+      - name: Build package artifacts
+        run: uv build

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -1,0 +1,53 @@
+name: Publish PyPI Package
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
+
+      - name: Build distributions
+        run: uv build
+
+      - name: Upload dist artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/project/ts-agents/
+    steps:
+      - name: Download dist artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/publish-sandbox-image.yml
+++ b/.github/workflows/publish-sandbox-image.yml
@@ -1,0 +1,47 @@
+name: Publish Sandbox Image
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository_owner }}/ts-agents-sandbox
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract image metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=tag
+            type=raw,value=latest
+
+      - name: Build and push sandbox image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.sandbox
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile.sandbox
+++ b/Dockerfile.sandbox
@@ -20,6 +20,7 @@ RUN apt-get update && \
 # Copy just the minimal project files for editable install.
 COPY pyproject.toml uv.lock README.md ./
 COPY src ./src
+COPY ts_agents ./ts_agents
 
 RUN python -m pip install --upgrade pip && \
     python -m pip install -e .

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ It ships with three out-of-the-box demos:
 - `window-classification --csv-path data/wisdm_subset.csv` (WISDM real accelerometer data)
 - `forecasting` (baseline comparison and report artifacts)
 
-**Start here:** [Quickstart](#quickstart) | [Choose your path](#choose-your-path) | [Docs site](https://fnauman.github.io/ts-agents/) | [Demo walkthroughs](docs/walkthroughs.qmd) | [Hosted demo guide](docs/huggingface-spaces.qmd)
+**Start here:** [Quickstart](#quickstart) | [Choose your path](#choose-your-path) | [Docs site](https://fnauman.github.io/ts-agents/) | [Distribution guide](docs/distribution.qmd) | [Demo walkthroughs](docs/walkthroughs.qmd) | [Hosted demo guide](docs/huggingface-spaces.qmd)
 
 ![ts-agents demo](demo/assets/demo.gif)
 
@@ -143,8 +143,14 @@ Local editable install from a source checkout:
 python -m pip install -e .
 ```
 
-PyPI and prebuilt container publishing are planned, but source install is the
-supported path today.
+Source install is the supported path today.
+
+Publishing setup in this repo targets:
+- PyPI package name: `ts-agents`
+- sandbox image: `ghcr.io/fnauman/ts-agents-sandbox`
+
+See [docs/distribution.qmd](docs/distribution.qmd) for the release, PyPI, and
+GHCR publishing flow.
 
 CLI entrypoints:
 - Preferred: `ts-agents ...`
@@ -175,6 +181,14 @@ public demos such as Hugging Face Spaces. It defaults to:
 - a public-safe configuration that does not require `OPENAI_API_KEY`
 
 See [docs/huggingface-spaces.qmd](docs/huggingface-spaces.qmd) for deployment instructions and optional agent-mode configuration.
+
+## Distribution
+
+- Package metadata is configured for the `ts-agents` distribution name.
+- GitHub Actions includes a PyPI publish workflow for tagged releases.
+- GitHub Actions includes a GHCR workflow for publishing the sandbox image built
+  from `Dockerfile.sandbox`.
+- GitHub release/tag/docs flow is summarized in [docs/distribution.qmd](docs/distribution.qmd).
 
 ## CLI Usage
 

--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -12,6 +12,8 @@ website:
         text: Quickstart
       - href: cli-examples.qmd
         text: CLI Examples
+      - href: distribution.qmd
+        text: Distribution
       - href: walkthroughs.qmd
         text: Walkthroughs
       - href: huggingface-spaces.qmd

--- a/docs/distribution.qmd
+++ b/docs/distribution.qmd
@@ -1,0 +1,59 @@
+---
+title: "Distribution"
+---
+
+This page captures the repo's distribution and publishing paths.
+
+## Python Package
+
+- Package name target: `ts-agents`
+- Build backend: `setuptools`
+- Build command:
+
+```bash
+uv build
+```
+
+Publishing automation lives in `.github/workflows/publish-pypi.yml`.
+
+The workflow is designed for GitHub Actions -> PyPI trusted publishing and runs
+on version tags (`v*`) or manual dispatch.
+
+## GitHub Release Flow
+
+Release tags use the form `vX.Y.Z`.
+
+Recommended release steps:
+
+1. update `CHANGELOG.md`
+2. create/push the git tag
+3. create the GitHub release
+4. run or verify the package/image publish workflows
+
+## Sandbox Container Image
+
+The sandbox container is built from `Dockerfile.sandbox`.
+
+- Local build:
+
+```bash
+./build_docker_sandbox.sh
+```
+
+- Published image target:
+
+```text
+ghcr.io/fnauman/ts-agents-sandbox
+```
+
+Automation lives in `.github/workflows/publish-sandbox-image.yml`.
+
+The published image is intended to give users a prebuilt sandbox backend instead
+of requiring a local Docker build before first use.
+
+## Notes
+
+- The source checkout remains the primary install path until the first PyPI
+  publish is completed.
+- The docs/README should only advertise `pip install ts-agents` after the first
+  successful publish.

--- a/docs/index.qmd
+++ b/docs/index.qmd
@@ -11,6 +11,7 @@ without rewriting the core toolchain.
 
 - [Quickstart](quickstart.qmd): install and run your first command in under a minute
 - [CLI Examples](cli-examples.qmd): practical CLI patterns by example
+- [Distribution](distribution.qmd): package publishing, GitHub releases, and GHCR sandbox image flow
 - [Walkthroughs](walkthroughs.qmd): step-by-step guides for the built-in demos
 - [Hugging Face Spaces](huggingface-spaces.qmd): deploy a public Gradio demo from the hosted `app.py` entrypoint
 - [Skills Guide](skills-guide.qmd): using, customizing, and creating skills

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,11 @@ dependencies = [
 ]
 
 [project.urls]
+Homepage = "https://fnauman.github.io/ts-agents/"
+Documentation = "https://fnauman.github.io/ts-agents/"
 Repository = "https://github.com/fnauman/ts-agents"
+Issues = "https://github.com/fnauman/ts-agents/issues"
+Changelog = "https://github.com/fnauman/ts-agents/blob/main/CHANGELOG.md"
 
 [project.scripts]
 ts-agents = "ts_agents.__main__:main"


### PR DESCRIPTION
## Summary
- add PyPI publishing workflow scaffolding for the `ts-agents` package name
- add GHCR publishing workflow scaffolding for the sandbox image
- tighten package metadata and include `ts_agents/` in the Docker sandbox image build
- add distribution docs and wire them into the README/docs nav

## Direct repo actions completed
- created GitHub release `v0.1.0`
- applied repository topics: `time-series`, `forecasting`, `agents`, `cli`, `mlops`

## Testing
- `UV_CACHE_DIR=/tmp/uv-cache uv build`
- local Docker sandbox build reached full dependency installation successfully; image export was extremely heavyweight because the current dependency graph pulls in large `torch`/CUDA wheels through `neuralforecast`

Closes #11
