### PR TITLE
Finish remaining release readiness tasks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,26 @@ on:
   pull_request:
 
 jobs:
+  quality:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
+
+      - name: Run release-surface quality checks
+        shell: bash
+        run: bash scripts/check_release_quality.sh
+
   tests:
     runs-on: ubuntu-latest
     strategy:

--- a/.gitignore
+++ b/.gitignore
@@ -13,9 +13,6 @@ wheels/
 !data/short_real.csv
 !data/wisdm_subset.csv
 !data/m4_monthly_mini.csv
-!src/resources/data/short_real.csv
-!src/resources/data/demo_labeled_stream.csv
-!src/resources/data/m4_monthly_mini.csv
 
 /outputs/*
 !/outputs/reports/

--- a/README.md
+++ b/README.md
@@ -141,6 +141,9 @@ The default install is intentionally all-in-one and pulls a fairly heavy
 forecasting/ML stack, including neural backends used by the shipped tool
 surface. There is not yet a slim extras-based install profile, so plan for a
 full scientific Python environment.
+The dependency minimums also intentionally track the currently validated
+`0.1.0` stack for this first alpha release; widening lower-bound compatibility
+is a follow-up task rather than part of the initial publish gate.
 
 Run the packaged entrypoints:
 

--- a/docs/distribution.qmd
+++ b/docs/distribution.qmd
@@ -29,15 +29,17 @@ Release tags use the form `vX.Y.Z`.
 Recommended release steps:
 
 1. update `CHANGELOG.md`
-2. run `uv run python -m pytest -q`
-3. run `uv build`
-4. run `uv tool run twine check dist/*`
-5. run `bash scripts/smoke_install_wheel.sh 3.12 dist`
-6. manually dispatch `publish-testpypi.yml`
-7. inspect the rendered TestPyPI project page and verify the install path there
-8. create/push the git tag
-9. create the GitHub release
-10. let `.github/workflows/publish-pypi.yml` publish the already-validated artifact
+2. run `bash scripts/clean_release_artifacts.sh`
+3. run `bash scripts/check_release_quality.sh`
+4. run `uv run python -m pytest -q`
+5. run `uv build`
+6. run `uv tool run twine check dist/*`
+7. run `bash scripts/smoke_install_wheel.sh 3.12 dist`
+8. manually dispatch `publish-testpypi.yml`
+9. inspect the rendered TestPyPI project page and verify the install path there
+10. create/push the git tag
+11. create the GitHub release
+12. let `.github/workflows/publish-pypi.yml` publish the already-validated artifact
 
 ## Sandbox Container Image
 
@@ -63,7 +65,11 @@ of requiring a local Docker build before first use.
 ## Notes
 
 - CI now builds once and smoke-tests the wheel on Python 3.11, 3.12, and 3.13.
+- CI also runs a narrow `ruff` + `mypy` quality gate over the release/package
+  surface.
 - The publish workflow also gates real PyPI publishing on the same artifact
   smoke matrix.
+- The current dependency minimums intentionally track the validated `0.1.0`
+  release stack; broader lower-bound compatibility can be widened later.
 - For the first public release, run the TestPyPI workflow and inspect the
   rendered page before creating the `v0.1.0` tag.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 license = "MIT"
 requires-python = ">=3.11,<3.14"
 authors = [
-    { name = "Farrukh Nauman" },
+    { name = "Farrukh Nauman", email = "farrukhnauman@yahoo.com" },
 ]
 keywords = ["time-series", "agents", "forecasting", "classification", "cli"]
 classifiers = [
@@ -18,6 +18,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Topic :: Scientific/Engineering",
+    "Typing :: Typed",
 ]
 dependencies = [
     "aeon>=1.3.0",

--- a/scripts/check_release_quality.sh
+++ b/scripts/check_release_quality.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+# Keep this quality scope focused on the packaged/release-facing surface until
+# broader repo-wide lint/type debt is addressed separately.
+TARGETS=(
+  app.py
+  main.py
+  ts_agents/__init__.py
+  ts_agents/config.py
+  ts_agents/runtime_paths.py
+  ts_agents/hosted_app.py
+  tests/test_package_metadata.py
+  tests/test_hosted_app.py
+  tests/cli/test_entrypoints.py
+)
+
+uv tool run ruff check "${TARGETS[@]}"
+uv tool run mypy \
+  --ignore-missing-imports \
+  --follow-imports skip \
+  "${TARGETS[@]}"

--- a/scripts/clean_release_artifacts.sh
+++ b/scripts/clean_release_artifacts.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+rm -rf "$ROOT/build" "$ROOT/dist" "$ROOT/wheels"
+find "$ROOT" -maxdepth 1 -type d -name '*.egg-info' -exec rm -rf {} +
+
+echo "release artifacts cleaned"

--- a/tests/test_package_metadata.py
+++ b/tests/test_package_metadata.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+import tomllib
 from importlib.metadata import PackageNotFoundError, version
 
 import ts_agents
@@ -10,3 +12,15 @@ def test_package_exposes_distribution_version():
         assert ts_agents.__version__ == "0.0.0.dev0"
     else:
         assert ts_agents.__version__ == dist_version
+
+
+def test_project_metadata_includes_release_hygiene_fields():
+    pyproject = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))
+    project = pyproject["project"]
+    classifiers = set(project["classifiers"])
+
+    assert any(author.get("email") for author in project["authors"])
+    assert project["license"] == "MIT"
+    assert "Intended Audience :: Developers" in classifiers
+    assert "Intended Audience :: Science/Research" in classifiers
+    assert "Typing :: Typed" in classifiers


### PR DESCRIPTION
Closes #34.

## What changed
- added the remaining release-hygiene metadata and tests
- added release cleanup and release-surface quality helper scripts
- added a CI quality job for the packaged/release-facing surface
- removed stale `.gitignore` entries and documented the dependency-floor decision plus the local release checklist flow

## Validation
- `bash scripts/clean_release_artifacts.sh`
- `bash scripts/check_release_quality.sh`
- `uv run python -m pytest -q tests/test_package_metadata.py tests/test_hosted_app.py tests/cli/test_entrypoints.py`
- `uv run python -m pytest -q`
- `uv build`
- `uv tool run twine check dist/*`
- `bash scripts/smoke_install_wheel.sh 3.12 dist`
- `publish-testpypi.yml` on this branch: build + smoke jobs passed; publish step failed because TestPyPI trusted publishing is configured for `main`, so the final TestPyPI validation must be rerun from `main` after merge

## Manifest / profile impacts
- package metadata now includes author email and a `Typing :: Typed` classifier
- CI gains a narrow `ruff` + `mypy` release-surface gate
- local release flow gains `scripts/clean_release_artifacts.sh` and `scripts/check_release_quality.sh`

## Risks
- the new quality job intentionally scopes lint/type checks to the release/package surface rather than the whole repo, so broader lint/type debt is still out of scope for this PR
