### PR TITLE
Prepare 0.1.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.1] - 2026-03-10
+
+Release-preparation and packaging hardening update for the first real PyPI
+publish.
+
+### Changed
+
+- bumped the release version to `0.1.1` after the stale `v0.1.0` Git tag was
+  found to point at an older pre-release commit
+- aligned the documented PyPI user path with the installed wheel entrypoints
+  and clarified which demo data is bundled versus source-checkout-only
+- capped the advertised Python support range to the validated 3.11-3.13 matrix
+  and declared missing direct runtime dependencies explicitly
+- added artifact-level release gates in CI and publish workflows, including
+  `twine check`, built-wheel smoke tests, TestPyPI validation, and tag/version
+  matching for the real PyPI publish workflow
+- tightened release metadata and tooling around the package surface, including
+  `py.typed`, `__version__`, metadata tests, release-surface quality checks,
+  deterministic pinned dev tools, and release helper scripts
+
+### Notes
+
+- Current package version is `0.1.1` in `pyproject.toml`.
+
 ## [0.1.0] - 2026-03-05
 
 Initial public release of `ts-agents`.

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ forecasting/ML stack, including neural backends used by the shipped tool
 surface. There is not yet a slim extras-based install profile, so plan for a
 full scientific Python environment.
 The dependency minimums also intentionally track the currently validated
-`0.1.0` stack for this first alpha release; widening lower-bound compatibility
+`0.1.1` stack for this alpha release; widening lower-bound compatibility
 is a follow-up task rather than part of the initial publish gate.
 
 Run the packaged entrypoints:

--- a/docs/distribution.qmd
+++ b/docs/distribution.qmd
@@ -69,7 +69,7 @@ of requiring a local Docker build before first use.
   surface.
 - The publish workflow also gates real PyPI publishing on the same artifact
   smoke matrix.
-- The current dependency minimums intentionally track the validated `0.1.0`
+- The current dependency minimums intentionally track the validated `0.1.1`
   release stack; broader lower-bound compatibility can be widened later.
-- For the first public release, run the TestPyPI workflow and inspect the
-  rendered page before creating the `v0.1.0` tag.
+- Before creating the real release tag, run the TestPyPI workflow and inspect
+  the rendered page for the exact artifact you plan to publish.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ts-agents"
-version = "0.1.0"
+version = "0.1.1"
 description = "Time series analysis toolkit with CLI, agents, and Gradio UI"
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -4314,7 +4314,7 @@ wheels = [
 
 [[package]]
 name = "ts-agents"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "aeon" },


### PR DESCRIPTION
## Summary
- bump the package version from `0.1.0` to `0.1.1`
- refresh the changelog and release-facing docs for the next real PyPI release
- regenerate `uv.lock` so the package metadata is consistent with the new version

## Why
`origin` already has a stale `v0.1.0` tag pointing at an older pre-release commit, while PyPI has not been published yet. Preparing `0.1.1` is the safe way to publish the current release-ready `main` state without rewriting tag history.

## Testing
- `bash scripts/clean_release_artifacts.sh`
- `UV_CACHE_DIR=/tmp/uv-cache uv run python -m pytest -q tests/test_package_metadata.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv lock`
- `UV_CACHE_DIR=/tmp/uv-cache uv build`
- `UV_CACHE_DIR=/tmp/uv-cache uv tool run twine check dist/*`
- `bash scripts/smoke_install_wheel.sh 3.12 dist`

Closes #38
