### PR TITLE
Make forecasting base profile safe by default

### DIFF
--- a/skills/forecasting/SKILL.md
+++ b/skills/forecasting/SKILL.md
@@ -11,7 +11,7 @@ metadata:
     tool_category: forecasting
     prefers_with_data_tools: true
     preferred_workflow: forecast-series
-    preferred_tools: [compare_forecasts_with_data, forecast_theta_with_data, forecast_ets_with_data]
+    preferred_tools: [detect_periodicity_with_data, forecast_seasonal_naive_with_data]
     artifact_checklist: [forecast_comparison.json, forecast.json, forecast.csv, report.md]
   claude_code:
     allowed-tools: [Bash, Read, Write, Edit]
@@ -46,10 +46,10 @@ If the season length is unknown and seasonality matters, estimate it first.
 
 ## Model selection cheat sheet
 - **Seasonal Naive**: minimum serious baseline for seasonal data. Cheap and easy to interpret.
-- **Theta**: strong simple baseline; often competitive.
-- **ETS**: good default for level/trend/seasonality.
-- **ARIMA**: stronger but more fragile and higher cost.
-- **Ensemble**: use after you have compared individual methods.
+- **Theta**: strong simple baseline; often competitive. Requires the optional `forecasting` extra.
+- **ETS**: good default for level/trend/seasonality. Requires the optional `forecasting` extra.
+- **ARIMA**: stronger but more fragile and higher cost. Requires the optional `forecasting` extra.
+- **Ensemble**: use after you have compared individual methods; advanced combinations require the optional `forecasting` extra.
 
 ## Workflow
 ### 0) Estimate seasonality when needed
@@ -57,60 +57,54 @@ If the season length is unknown and seasonality matters, estimate it first.
 uv run ts-agents tool run detect_periodicity_with_data --run <RUN_ID> --var <VARIABLE> --param n_top=3
 ```
 
-### 1) Start with a baseline
-If the series is seasonal and you know the period:
+### 1) Check which methods are available in the current environment
+```bash
+uv run ts-agents workflow show forecast-series --json
+```
+
+Interpret `available_methods` / `unavailable_methods` before you choose models.
+In a default/base install, expect `seasonal_naive` to be available and
+`theta`, `ets`, `arima` to remain unavailable until the optional
+`forecasting` extra is installed.
+
+### 2) Run a base-safe baseline and artifact workflow
+```bash
+uv run ts-agents workflow run forecast-series \
+  --run-id <RUN_ID> --variable <VARIABLE> \
+  --horizon 50 \
+  --methods seasonal_naive \
+  --season-length <PERIOD>
+```
+
+If you only need a quick point forecast instead of the workflow artifact set:
 ```bash
 uv run ts-agents tool run forecast_seasonal_naive_with_data \
   --run <RUN_ID> --var <VARIABLE> \
   --param horizon=50 --param season_length=<PERIOD>
 ```
 
-If you do not know the period yet, or need a stronger fast baseline:
-```bash
-uv run ts-agents tool run forecast_theta_with_data \
-  --run <RUN_ID> --var <VARIABLE> \
-  --param horizon=50 --param season_length=<PERIOD>
-```
-
-### 2) Add ETS or ARIMA when accuracy matters
-```bash
-uv run ts-agents tool run forecast_ets_with_data \
-  --run <RUN_ID> --var <VARIABLE> \
-  --param horizon=50 --param season_length=<PERIOD>
-
-uv run ts-agents tool run forecast_arima_with_data \
-  --run <RUN_ID> --var <VARIABLE> \
-  --param horizon=50 --param season_length=<PERIOD>
-```
-
-### 3) Compare explicitly instead of relying on defaults
-```bash
-uv run ts-agents tool run compare_forecasts_with_data \
-  --run <RUN_ID> --var <VARIABLE> \
-  --param horizon=50 \
-  --param models=seasonal_naive,theta,ets,arima \
-  --param season_length=<PERIOD>
-```
+### 3) Expand the comparison only after confirming advanced backends are available
 
 Notes:
 - The comparison tool uses a simple historical split, not the professional
   rolling-origin + official holdout protocol.
 - Use this when the user asks "which model looks best on this series?"
+- If `workflow show forecast-series --json` lists `theta`, `ets`, or `arima`
+  in `available_methods`, rerun the same workflow with those method names
+  added to `--methods`.
+- If those methods are listed under `unavailable_methods`, stay with
+  `seasonal_naive` or install `ts-agents[forecasting]`.
 
 ### 4) Use an ensemble only after individual comparisons
-```bash
-uv run ts-agents tool run forecast_ensemble_with_data \
-  --run <RUN_ID> --var <VARIABLE> \
-  --param horizon=50 \
-  --param models=seasonal_naive,theta,ets,arima \
-  --param season_length=<PERIOD>
-```
+Treat ensembles as an advanced path, not a base-profile default. Only use them
+after individual methods are available and have been compared explicitly.
 
 ## Prediction intervals
 The core forecasting functions support `level=[80, 95]`, while the
 `*_with_data` wrappers are mainly geared toward point forecasts and plots.
 
-If you need intervals, use Python directly:
+If you need interval-capable statistical models such as ETS, Theta, or ARIMA,
+install `ts-agents[forecasting]` and use Python directly:
 ```python
 from ts_agents.data_access import get_series
 from ts_agents.core.forecasting import forecast_ets

--- a/tests/cli/test_params.py
+++ b/tests/cli/test_params.py
@@ -422,7 +422,7 @@ def test_tool_show_json_reports_optional_backend_for_seasonal_naive(capsys):
     assert result["availability"]["optional_features"][0]["name"] == "statsforecast_backend"
 
 
-def test_tool_show_text_surfaces_optional_backend_install_hint_when_backend_missing(
+def test_tool_show_text_reports_optional_backend_without_install_hint_when_backend_missing(
     monkeypatch,
     capsys,
 ):
@@ -441,8 +441,35 @@ def test_tool_show_text_surfaces_optional_backend_install_hint_when_backend_miss
 
     assert code == 0
     output = capsys.readouterr().out
-    assert "Install hint:" in output
-    assert "ts-agents[forecasting]" in output
+    assert "Install hint:" not in output
+    assert "Optional features:" in output
+    assert "statsforecast_backend [unavailable] extras=forecasting" in output
+
+
+def test_tool_show_json_omits_install_hint_for_optional_backend_when_backend_missing(
+    monkeypatch,
+    capsys,
+):
+    import ts_agents.tools.registry as registry_mod
+
+    real_available = registry_mod._module_available
+
+    def fake_available(module_name: str) -> bool:
+        if module_name == "statsforecast":
+            return False
+        return real_available(module_name)
+
+    monkeypatch.setattr(registry_mod, "_module_available", fake_available)
+
+    code = run(["tool", "show", "forecast_seasonal_naive", "--json"])
+
+    assert code == 0
+    payload = json.loads(capsys.readouterr().out)
+    availability = payload["result"]["availability"]
+    assert availability["available"] is True
+    assert availability["install_hint"] is None
+    assert availability["optional_features"][0]["name"] == "statsforecast_backend"
+    assert availability["optional_features"][0]["available"] is False
 
 
 def test_tool_show_json_unknown_tool_is_typed(capsys):

--- a/tests/cli/test_skills.py
+++ b/tests/cli/test_skills.py
@@ -14,7 +14,8 @@ def test_skills_show_json_returns_structured_metadata(capsys):
     assert "commands" in payload["result"]
     assert "command_templates" in payload["result"]
     assert payload["result"]["path"].endswith("skills/forecasting/SKILL.md")
-    assert any(command.startswith("ts-agents tool run forecast_theta_with_data") for command in payload["result"]["commands"])
+    assert any(command.startswith("ts-agents workflow show forecast-series") for command in payload["result"]["commands"])
+    assert any(command.startswith("ts-agents workflow run forecast-series") for command in payload["result"]["commands"])
     assert not any(command.endswith("\\") for command in payload["result"]["commands"])
 
 

--- a/tests/core/test_comparison.py
+++ b/tests/core/test_comparison.py
@@ -1,7 +1,16 @@
 """Tests for the comparison module."""
 
+import importlib.util
+
 import numpy as np
 import pytest
+
+
+HAS_STATSFORECAST = importlib.util.find_spec("statsforecast") is not None
+requires_statsforecast = pytest.mark.skipif(
+    not HAS_STATSFORECAST,
+    reason="statsforecast not installed",
+)
 
 
 class TestComparisonResult:
@@ -162,6 +171,7 @@ class TestDecompositionComparison:
 class TestForecastingComparison:
     """Tests for forecasting method comparison."""
 
+    @requires_statsforecast
     def test_compare_forecasting_methods(self):
         """Test comparing forecasting methods."""
         from ts_agents.core.comparison import compare_forecasting_methods
@@ -180,6 +190,7 @@ class TestForecastingComparison:
         assert len(result.methods) >= 1
         assert result.recommendation is not None
 
+    @requires_statsforecast
     def test_forecasting_metrics(self):
         """Test that forecasting comparison includes error metrics."""
         from ts_agents.core.comparison import compare_forecasting_methods

--- a/tests/core/test_forecasting.py
+++ b/tests/core/test_forecasting.py
@@ -1,13 +1,23 @@
 """Tests for the forecasting module."""
 
+import importlib.util
+
 import numpy as np
 import pytest
 import pandas as pd
 
 
+HAS_STATSFORECAST = importlib.util.find_spec("statsforecast") is not None
+requires_statsforecast = pytest.mark.skipif(
+    not HAS_STATSFORECAST,
+    reason="statsforecast not installed",
+)
+
+
 class TestForecasting:
     """Tests for forecasting functions."""
 
+    @requires_statsforecast
     def test_forecast_arima(self):
         """Test ARIMA forecasting."""
         from ts_agents.core.forecasting import forecast_arima
@@ -21,6 +31,7 @@ class TestForecasting:
         assert len(result.forecast) == 20
         assert result.horizon == 20
 
+    @requires_statsforecast
     def test_forecast_ets(self):
         """Test ETS forecasting."""
         from ts_agents.core.forecasting import forecast_ets
@@ -32,6 +43,7 @@ class TestForecasting:
         assert result.method == "auto_ets"
         assert len(result.forecast) == 20
 
+    @requires_statsforecast
     def test_forecast_theta(self):
         """Test Theta forecasting."""
         from ts_agents.core.forecasting import forecast_theta
@@ -76,6 +88,7 @@ class TestForecasting:
         assert result.method == "seasonal_naive"
         np.testing.assert_allclose(result.forecast, np.array([1, 2, 3, 4, 1, 2], dtype=float))
 
+    @requires_statsforecast
     def test_forecast_ensemble(self):
         """Test ensemble forecasting."""
         from ts_agents.core.forecasting import forecast_ensemble
@@ -139,6 +152,7 @@ class TestForecasting:
             np.array([1, 2, 3, 4], dtype=float),
         )
 
+    @requires_statsforecast
     def test_forecast_arima_with_season_length(self):
         """Test ARIMA forecasting with season_length parameter."""
         from ts_agents.core.forecasting import forecast_arima
@@ -152,6 +166,7 @@ class TestForecasting:
         assert result.method == "auto_arima"
         assert len(result.forecast) == 12
 
+    @requires_statsforecast
     def test_forecast_ensemble_with_season_length(self):
         """Test ensemble forecasting with season_length parameter."""
         from ts_agents.core.forecasting import forecast_ensemble
@@ -169,6 +184,22 @@ class TestForecasting:
         import ts_agents.core.forecasting.statistical as statistical
 
         captured_freqs = []
+
+        class DummyModel:
+            def __init__(self, season_length=None):
+                self.season_length = season_length
+
+        class AutoARIMA(DummyModel):
+            pass
+
+        class AutoETS(DummyModel):
+            pass
+
+        class AutoTheta(DummyModel):
+            pass
+
+        class SeasonalNaive(DummyModel):
+            pass
 
         class DummyStatsForecast:
             def __init__(self, models, freq, n_jobs):
@@ -188,7 +219,17 @@ class TestForecasting:
                         data[f"{name}-hi-{level[0]}"] = np.zeros(h)
                 return pd.DataFrame(data)
 
-        monkeypatch.setattr(statistical, "StatsForecast", DummyStatsForecast)
+        monkeypatch.setattr(
+            statistical,
+            "_get_statsforecast_components",
+            lambda: (
+                DummyStatsForecast,
+                AutoARIMA,
+                AutoETS,
+                AutoTheta,
+                SeasonalNaive,
+            ),
+        )
 
         t = np.arange(120)
         x = np.sin(2 * np.pi * t / 12)
@@ -208,6 +249,7 @@ class TestForecasting:
         assert captured_freqs == [1, 1, 1, 1, 1]
         assert all(isinstance(freq, int) for freq in captured_freqs)
 
+    @requires_statsforecast
     def test_compare_forecasts(self):
         """Test forecast comparison."""
         from ts_agents.core.forecasting import compare_forecasts

--- a/tests/tools/test_registry.py
+++ b/tests/tools/test_registry.py
@@ -100,6 +100,30 @@ class TestToolRegistry:
         assert availability["required_extras"] == []
         assert availability["optional_features"][0]["name"] == "statsforecast_backend"
 
+    def test_forecast_seasonal_naive_omits_install_hint_when_only_optional_backend_is_missing(
+        self,
+        monkeypatch,
+    ):
+        """Missing optional backends should not look like missing required deps."""
+        from ts_agents.tools.registry import ToolRegistry, tool_availability
+        import ts_agents.tools.registry as registry_mod
+
+        real_available = registry_mod._module_available
+
+        def fake_available(module_name: str) -> bool:
+            if module_name == "statsforecast":
+                return False
+            return real_available(module_name)
+
+        monkeypatch.setattr(registry_mod, "_module_available", fake_available)
+
+        tool = ToolRegistry.get("forecast_seasonal_naive")
+        availability = tool_availability(tool)
+
+        assert availability["available"] is True
+        assert availability["install_hint"] is None
+        assert availability["optional_features"][0]["available"] is False
+
     def test_segment_changepoint_with_data_has_expected_params(self):
         """Test segment_changepoint_with_data exposes core controls + compatibility alias."""
         from ts_agents.tools.registry import ToolRegistry

--- a/ts_agents/cli/main.py
+++ b/ts_agents/cli/main.py
@@ -1892,6 +1892,16 @@ def _handle_tool_command(args: argparse.Namespace) -> Tuple[Any, str]:
             lines.append(f"Required extras: {', '.join(result['required_extras'])}")
         if install_hint:
             lines.append(f"Install hint: {install_hint}")
+        optional_features = availability.get("optional_features") or []
+        if optional_features:
+            lines.append("Optional features:")
+            for feature in optional_features:
+                state = "available" if feature.get("available") else "unavailable"
+                extras = feature.get("required_extras") or []
+                extras_suffix = f" extras={','.join(extras)}" if extras else ""
+                note = feature.get("note")
+                detail = f": {note}" if note else ""
+                lines.append(f"- {feature['name']} [{state}]{extras_suffix}{detail}")
         if tool.parameters:
             lines.append("Parameters:")
             for param in tool.parameters:

--- a/ts_agents/resources/skills/forecasting/SKILL.md
+++ b/ts_agents/resources/skills/forecasting/SKILL.md
@@ -11,7 +11,7 @@ metadata:
     tool_category: forecasting
     prefers_with_data_tools: true
     preferred_workflow: forecast-series
-    preferred_tools: [compare_forecasts_with_data, forecast_theta_with_data, forecast_ets_with_data]
+    preferred_tools: [detect_periodicity_with_data, forecast_seasonal_naive_with_data]
     artifact_checklist: [forecast_comparison.json, forecast.json, forecast.csv, report.md]
   claude_code:
     allowed-tools: [Bash, Read, Write, Edit]
@@ -46,10 +46,10 @@ If the season length is unknown and seasonality matters, estimate it first.
 
 ## Model selection cheat sheet
 - **Seasonal Naive**: minimum serious baseline for seasonal data. Cheap and easy to interpret.
-- **Theta**: strong simple baseline; often competitive.
-- **ETS**: good default for level/trend/seasonality.
-- **ARIMA**: stronger but more fragile and higher cost.
-- **Ensemble**: use after you have compared individual methods.
+- **Theta**: strong simple baseline; often competitive. Requires the optional `forecasting` extra.
+- **ETS**: good default for level/trend/seasonality. Requires the optional `forecasting` extra.
+- **ARIMA**: stronger but more fragile and higher cost. Requires the optional `forecasting` extra.
+- **Ensemble**: use after you have compared individual methods; advanced combinations require the optional `forecasting` extra.
 
 ## Workflow
 ### 0) Estimate seasonality when needed
@@ -57,60 +57,54 @@ If the season length is unknown and seasonality matters, estimate it first.
 uv run ts-agents tool run detect_periodicity_with_data --run <RUN_ID> --var <VARIABLE> --param n_top=3
 ```
 
-### 1) Start with a baseline
-If the series is seasonal and you know the period:
+### 1) Check which methods are available in the current environment
+```bash
+uv run ts-agents workflow show forecast-series --json
+```
+
+Interpret `available_methods` / `unavailable_methods` before you choose models.
+In a default/base install, expect `seasonal_naive` to be available and
+`theta`, `ets`, `arima` to remain unavailable until the optional
+`forecasting` extra is installed.
+
+### 2) Run a base-safe baseline and artifact workflow
+```bash
+uv run ts-agents workflow run forecast-series \
+  --run-id <RUN_ID> --variable <VARIABLE> \
+  --horizon 50 \
+  --methods seasonal_naive \
+  --season-length <PERIOD>
+```
+
+If you only need a quick point forecast instead of the workflow artifact set:
 ```bash
 uv run ts-agents tool run forecast_seasonal_naive_with_data \
   --run <RUN_ID> --var <VARIABLE> \
   --param horizon=50 --param season_length=<PERIOD>
 ```
 
-If you do not know the period yet, or need a stronger fast baseline:
-```bash
-uv run ts-agents tool run forecast_theta_with_data \
-  --run <RUN_ID> --var <VARIABLE> \
-  --param horizon=50 --param season_length=<PERIOD>
-```
-
-### 2) Add ETS or ARIMA when accuracy matters
-```bash
-uv run ts-agents tool run forecast_ets_with_data \
-  --run <RUN_ID> --var <VARIABLE> \
-  --param horizon=50 --param season_length=<PERIOD>
-
-uv run ts-agents tool run forecast_arima_with_data \
-  --run <RUN_ID> --var <VARIABLE> \
-  --param horizon=50 --param season_length=<PERIOD>
-```
-
-### 3) Compare explicitly instead of relying on defaults
-```bash
-uv run ts-agents tool run compare_forecasts_with_data \
-  --run <RUN_ID> --var <VARIABLE> \
-  --param horizon=50 \
-  --param models=seasonal_naive,theta,ets,arima \
-  --param season_length=<PERIOD>
-```
+### 3) Expand the comparison only after confirming advanced backends are available
 
 Notes:
 - The comparison tool uses a simple historical split, not the professional
   rolling-origin + official holdout protocol.
 - Use this when the user asks "which model looks best on this series?"
+- If `workflow show forecast-series --json` lists `theta`, `ets`, or `arima`
+  in `available_methods`, rerun the same workflow with those method names
+  added to `--methods`.
+- If those methods are listed under `unavailable_methods`, stay with
+  `seasonal_naive` or install `ts-agents[forecasting]`.
 
 ### 4) Use an ensemble only after individual comparisons
-```bash
-uv run ts-agents tool run forecast_ensemble_with_data \
-  --run <RUN_ID> --var <VARIABLE> \
-  --param horizon=50 \
-  --param models=seasonal_naive,theta,ets,arima \
-  --param season_length=<PERIOD>
-```
+Treat ensembles as an advanced path, not a base-profile default. Only use them
+after individual methods are available and have been compared explicitly.
 
 ## Prediction intervals
 The core forecasting functions support `level=[80, 95]`, while the
 `*_with_data` wrappers are mainly geared toward point forecasts and plots.
 
-If you need intervals, use Python directly:
+If you need interval-capable statistical models such as ETS, Theta, or ARIMA,
+install `ts-agents[forecasting]` and use Python directly:
 ```python
 from ts_agents.data_access import get_series
 from ts_agents.core.forecasting import forecast_ets

--- a/ts_agents/tools/registry.py
+++ b/ts_agents/tools/registry.py
@@ -216,9 +216,6 @@ def tool_availability(tool: ToolMetadata) -> Dict[str, Any]:
     missing_required = [
         dependency for dependency in tool.dependencies if not _module_available(dependency)
     ]
-    missing_optional = [
-        dependency for dependency in tool.optional_dependencies if not _module_available(dependency)
-    ]
     required_extras = sorted(
         {
             extra
@@ -246,7 +243,7 @@ def tool_availability(tool: ToolMetadata) -> Dict[str, Any]:
         "missing_dependencies": missing_required,
         "required_extras": required_extras,
         "optional_features": optional_features,
-        "install_hint": tool_install_hint(tool) if (missing_required or missing_optional) else None,
+        "install_hint": tool_install_hint(tool) if missing_required else None,
     }
 
 


### PR DESCRIPTION
Closes #71

## Summary
- skip StatsForecast-only core tests in the base profile while keeping seasonal-naive fallback coverage active
- rewrite the forecasting skill and packaged mirror around base-safe workflow/tool commands and availability checks
- stop surfacing generic install hints when only optional forecasting backends are missing, and show optional feature notes in `tool show`

## Behavior Changes
- base installs no longer fail core forecasting/comparison tests that require the optional `forecasting` extra
- the packaged forecasting skill now defaults to commands that run in the base profile
- `tool show forecast_seasonal_naive` no longer implies the tool is unusable without StatsForecast

## Tests
- `uv run python -m pytest -q tests/core/test_forecasting.py tests/core/test_comparison.py tests/tools/test_registry.py tests/cli/test_params.py tests/cli/test_skills.py`

## Manifest/Profile Impact
- no dependency manifest changes
- clarifies the default/base profile contract for forecasting-related tests, skills, and tool metadata

## Risks
- skill guidance is now more workflow-first; any consumers that expected the previous advanced method examples will see different extracted command templates
- verification was focused on the touched forecasting/CLI suites rather than the full repo test matrix