### PR TITLE
Fix Docker sandbox image readiness checks

### DIFF
--- a/tests/cli/test_sandbox.py
+++ b/tests/cli/test_sandbox.py
@@ -42,7 +42,7 @@ def test_sandbox_doctor_local_json_returns_backend_status(capsys):
 
 
 def test_sandbox_doctor_docker_json_reports_missing_image(monkeypatch, capsys):
-    def fake_describe(_backend):
+    def fake_describe(_backend, context=None, backend=None):
         return {
             "backend": "docker",
             "description": "Containerized execution through Docker.",

--- a/tests/cli/test_sandbox.py
+++ b/tests/cli/test_sandbox.py
@@ -41,6 +41,35 @@ def test_sandbox_doctor_local_json_returns_backend_status(capsys):
     assert payload["result"]["available"] is True
 
 
+def test_sandbox_doctor_docker_json_reports_missing_image(monkeypatch, capsys):
+    def fake_describe(_backend):
+        return {
+            "backend": "docker",
+            "description": "Containerized execution through Docker.",
+            "available": False,
+            "reason": "Docker image 'ts-agents-sandbox:latest' is not available locally.",
+            "suggested_fix": "Build or pull 'ts-agents-sandbox:latest', set TS_AGENTS_DOCKER_IMAGE to an available image, or run with --sandbox local.",
+            "requirements": [
+                "Docker CLI installed.",
+                "Docker daemon running.",
+                "Sandbox image available.",
+            ],
+            "details": {"image": "ts-agents-sandbox:latest"},
+        }
+
+    import ts_agents.tools.executor as executor_mod
+    monkeypatch.setattr(executor_mod, "describe_sandbox_backend", fake_describe)
+
+    code = run(["sandbox", "doctor", "docker", "--json"])
+
+    assert code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["ok"] is True
+    assert payload["name"] == "docker"
+    assert payload["result"]["available"] is False
+    assert payload["result"]["reason"] == "Docker image 'ts-agents-sandbox:latest' is not available locally."
+
+
 def test_tool_run_backend_unavailable_returns_typed_json(monkeypatch, capsys):
     import ts_agents.tools.executor as executor_mod
 

--- a/tests/cli/test_workflows.py
+++ b/tests/cli/test_workflows.py
@@ -372,6 +372,7 @@ def test_workflow_executor_skips_host_availability_gate_for_docker(monkeypatch):
     from ts_agents.tools.executor import ExecutionContext, ExecutionResult, ExecutionStatus, SandboxMode
 
     backend_calls = {}
+    probe_calls = {}
 
     class FakeDockerBackend:
         def is_available(self):
@@ -408,7 +409,9 @@ def test_workflow_executor_skips_host_availability_gate_for_docker(monkeypatch):
     monkeypatch.setattr(
         workflow_executor_mod,
         "describe_sandbox_backend",
-        lambda mode: {
+        lambda mode, context=None, backend=None: probe_calls.update(
+            {"mode": mode, "context": context, "backend": backend}
+        ) or {
             "backend": mode.value,
             "available": True,
             "reason": None,
@@ -419,15 +422,19 @@ def test_workflow_executor_skips_host_availability_gate_for_docker(monkeypatch):
         },
     )
 
+    context = ExecutionContext(sandbox_mode="docker")
     result = executor.execute(
         "forecast-series",
         SeriesInput(series=np.array([1.0, 2.0, 3.0]), source_type="inline_json", label="series"),
         {"output_dir": "outputs/forecast", "horizon": 2, "methods": ["arima"]},
-        context=ExecutionContext(sandbox_mode="docker"),
+        context=context,
     )
 
     assert result.success is True
     assert backend_calls["tool_name"] == "workflow:forecast-series"
+    assert probe_calls["mode"] == SandboxMode.DOCKER
+    assert probe_calls["context"] is context
+    assert probe_calls["backend"] is executor.backends[SandboxMode.DOCKER]
 
 
 def test_run_serialized_workflow_bundles_remote_artifacts(monkeypatch, tmp_path):
@@ -601,7 +608,7 @@ def test_workflow_executor_materializes_remote_artifacts_to_requested_output_dir
     monkeypatch.setattr(
         workflow_executor_mod,
         "describe_sandbox_backend",
-        lambda mode: {
+        lambda mode, context=None, backend=None: {
             "backend": mode.value,
             "available": True,
             "reason": None,

--- a/tests/tools/test_executor.py
+++ b/tests/tools/test_executor.py
@@ -1,6 +1,7 @@
 """Tests for tool executor serialization and context handling."""
 
 import json
+import subprocess
 import shutil
 from pathlib import Path
 
@@ -18,6 +19,7 @@ from ts_agents.tools.executor import (
     ToolExecutor,
     _persist_docker_artifacts,
     _persist_subprocess_artifacts,
+    describe_sandbox_backend,
 )
 from ts_agents.tools.results import DecompositionResult as ToolDecompositionResult
 
@@ -202,6 +204,35 @@ def test_local_backend_formats_tool_payload_with_artifacts():
     assert "/tmp/peaks.png" in result.formatted_output
 
 
+def test_describe_sandbox_backend_docker_reports_missing_image(monkeypatch):
+    import ts_agents.tools.executor as executor_mod
+
+    monkeypatch.setattr(executor_mod.shutil, "which", lambda name: "/usr/bin/docker")
+
+    def fake_run(cmd, capture_output=True, text=True, timeout=5):
+        if cmd[:3] == ["docker", "version", "--format"]:
+            return subprocess.CompletedProcess(cmd, 0, stdout="29.3.1\n", stderr="")
+        if cmd[:3] == ["docker", "image", "inspect"]:
+            return subprocess.CompletedProcess(
+                cmd,
+                1,
+                stdout="",
+                stderr="Error: No such image: ts-agents-sandbox:latest\n",
+            )
+        raise AssertionError(f"Unexpected command: {cmd}")
+
+    monkeypatch.setattr(executor_mod.subprocess, "run", fake_run)
+
+    status = describe_sandbox_backend("docker")
+
+    assert status["backend"] == "docker"
+    assert status["available"] is False
+    assert status["reason"] == "Docker image 'ts-agents-sandbox:latest' is not available locally."
+    assert "Build or pull 'ts-agents-sandbox:latest'" in status["suggested_fix"]
+    assert status["details"]["image"] == "ts-agents-sandbox:latest"
+    assert "No such image" in status["details"]["image_probe_error"]
+
+
 def test_tool_executor_returns_backend_unavailable_without_fallback(monkeypatch):
     import ts_agents.tools.executor as executor_mod
 
@@ -243,6 +274,53 @@ def test_tool_executor_returns_backend_unavailable_without_fallback(monkeypatch)
     assert result.metadata["backend_requested"] == "docker"
     assert result.metadata["backend_actual"] is None
     assert result.metadata["fallback_allowed"] is False
+
+
+def test_tool_executor_can_fallback_to_local_when_docker_image_is_missing(monkeypatch):
+    import ts_agents.tools.executor as executor_mod
+
+    executor = ToolExecutor(default_backend=SandboxMode.LOCAL)
+
+    def fake_describe(mode):
+        if mode == SandboxMode.DOCKER:
+            return {
+                "backend": "docker",
+                "available": False,
+                "reason": "Docker image 'ts-agents-sandbox:latest' is not available locally.",
+                "suggested_fix": "Build or pull 'ts-agents-sandbox:latest', set TS_AGENTS_DOCKER_IMAGE to an available image, or run with --sandbox local.",
+                "requirements": [],
+                "details": {"image": "ts-agents-sandbox:latest"},
+                "description": "Containerized execution through Docker.",
+            }
+        return {
+            "backend": mode.value,
+            "available": True,
+            "reason": None,
+            "suggested_fix": None,
+            "requirements": [],
+            "details": {},
+            "description": "backend",
+        }
+
+    monkeypatch.setattr(executor_mod, "describe_sandbox_backend", fake_describe)
+    monkeypatch.setattr(executor.backends[SandboxMode.DOCKER], "is_available", lambda: True)
+    monkeypatch.setattr(executor.backends[SandboxMode.LOCAL], "is_available", lambda: True)
+
+    result = executor.execute(
+        "describe_series",
+        {"series": [1, 2, 3]},
+        context=ExecutionContext(
+            sandbox_mode="docker",
+            allow_fallback=True,
+            fallback_backend="local",
+        ),
+    )
+
+    assert result.success is True
+    assert result.metadata["backend_requested"] == "docker"
+    assert result.metadata["backend_actual"] == "local"
+    assert result.metadata["fallback_used"] is True
+    assert result.metadata["fallback_allowed"] is True
 
 
 def test_tool_executor_can_fallback_to_local_when_allowed(monkeypatch):

--- a/tests/tools/test_executor.py
+++ b/tests/tools/test_executor.py
@@ -1,8 +1,8 @@
 """Tests for tool executor serialization and context handling."""
 
 import json
-import subprocess
 import shutil
+import subprocess
 from pathlib import Path
 
 import numpy as np
@@ -233,12 +233,127 @@ def test_describe_sandbox_backend_docker_reports_missing_image(monkeypatch):
     assert "No such image" in status["details"]["image_probe_error"]
 
 
+def test_describe_sandbox_backend_docker_honors_context_image_override(monkeypatch):
+    import ts_agents.tools.executor as executor_mod
+
+    seen_images = []
+
+    monkeypatch.setattr(executor_mod.shutil, "which", lambda name: "/usr/bin/docker")
+
+    def fake_run(cmd, capture_output=True, text=True, timeout=5):
+        if cmd[:3] == ["docker", "version", "--format"]:
+            return subprocess.CompletedProcess(cmd, 0, stdout="29.3.1\n", stderr="")
+        if cmd[:3] == ["docker", "image", "inspect"]:
+            seen_images.append(cmd[3])
+            return subprocess.CompletedProcess(cmd, 0, stdout="sha256:custom\n", stderr="")
+        raise AssertionError(f"Unexpected command: {cmd}")
+
+    monkeypatch.setattr(executor_mod.subprocess, "run", fake_run)
+
+    status = describe_sandbox_backend(
+        "docker",
+        context=ExecutionContext(sandbox_mode="docker", docker_image="custom:ready"),
+    )
+
+    assert status["available"] is True
+    assert status["details"]["image"] == "custom:ready"
+    assert status["details"]["image_id"] == "sha256:custom"
+    assert seen_images == ["custom:ready"]
+
+
+def test_describe_sandbox_backend_docker_honors_backend_image_default(monkeypatch):
+    import ts_agents.tools.executor as executor_mod
+
+    seen_images = []
+
+    monkeypatch.delenv("TS_AGENTS_DOCKER_IMAGE", raising=False)
+    monkeypatch.setattr(executor_mod.shutil, "which", lambda name: "/usr/bin/docker")
+
+    def fake_run(cmd, capture_output=True, text=True, timeout=5):
+        if cmd[:3] == ["docker", "version", "--format"]:
+            return subprocess.CompletedProcess(cmd, 0, stdout="29.3.1\n", stderr="")
+        if cmd[:3] == ["docker", "image", "inspect"]:
+            seen_images.append(cmd[3])
+            return subprocess.CompletedProcess(cmd, 0, stdout="sha256:backend\n", stderr="")
+        raise AssertionError(f"Unexpected command: {cmd}")
+
+    monkeypatch.setattr(executor_mod.subprocess, "run", fake_run)
+
+    status = describe_sandbox_backend(
+        "docker",
+        backend=executor_mod.DockerBackend(image="backend:ready"),
+    )
+
+    assert status["available"] is True
+    assert status["details"]["image"] == "backend:ready"
+    assert status["details"]["image_id"] == "sha256:backend"
+    assert seen_images == ["backend:ready"]
+
+
+def test_tool_executor_passes_context_and_backend_to_readiness_probe(monkeypatch):
+    import ts_agents.tools.executor as executor_mod
+
+    class FakeDockerBackend:
+        image = "backend:ready"
+
+        def is_available(self):
+            return True
+
+        def execute(self, tool_name, func, params, context):
+            return ExecutionResult(
+                status=ExecutionStatus.SUCCESS,
+                result={"kind": "analysis", "data": {}, "artifacts": []},
+                formatted_output="ok",
+                metadata={"backend": "docker"},
+            )
+
+    executor = ToolExecutor(
+        default_backend=SandboxMode.LOCAL,
+        backends={
+            SandboxMode.LOCAL: LocalBackend(),
+            SandboxMode.DOCKER: FakeDockerBackend(),
+            SandboxMode.DAYTONA: executor_mod.DaytonaBackend(),
+            SandboxMode.MODAL: executor_mod.ModalBackend(),
+            SandboxMode.SUBPROCESS: executor_mod.SubprocessBackend(),
+        },
+    )
+    observed = {}
+
+    def fake_describe(mode, context=None, backend=None):
+        observed["mode"] = mode
+        observed["context"] = context
+        observed["backend"] = backend
+        return {
+            "backend": mode.value,
+            "available": True,
+            "reason": None,
+            "suggested_fix": None,
+            "requirements": [],
+            "details": {},
+            "description": "backend",
+        }
+
+    monkeypatch.setattr(executor_mod, "describe_sandbox_backend", fake_describe)
+
+    context = ExecutionContext(sandbox_mode="docker", docker_image="custom:ready")
+    result = executor.execute(
+        "describe_series",
+        {"series": [1, 2, 3]},
+        context=context,
+    )
+
+    assert result.success is True
+    assert observed["mode"] == SandboxMode.DOCKER
+    assert observed["context"] is context
+    assert observed["backend"] is executor.backends[SandboxMode.DOCKER]
+
+
 def test_tool_executor_returns_backend_unavailable_without_fallback(monkeypatch):
     import ts_agents.tools.executor as executor_mod
 
     executor = ToolExecutor(default_backend=SandboxMode.LOCAL)
 
-    def fake_describe(mode):
+    def fake_describe(mode, context=None, backend=None):
         if mode == SandboxMode.DOCKER:
             return {
                 "backend": "docker",
@@ -281,7 +396,7 @@ def test_tool_executor_can_fallback_to_local_when_docker_image_is_missing(monkey
 
     executor = ToolExecutor(default_backend=SandboxMode.LOCAL)
 
-    def fake_describe(mode):
+    def fake_describe(mode, context=None, backend=None):
         if mode == SandboxMode.DOCKER:
             return {
                 "backend": "docker",
@@ -328,7 +443,7 @@ def test_tool_executor_can_fallback_to_local_when_allowed(monkeypatch):
 
     executor = ToolExecutor(default_backend=SandboxMode.LOCAL)
 
-    def fake_describe(mode):
+    def fake_describe(mode, context=None, backend=None):
         if mode == SandboxMode.DOCKER:
             return {
                 "backend": "docker",
@@ -374,7 +489,7 @@ def test_tool_executor_rejects_unavailable_fallback_backend(monkeypatch):
 
     executor = ToolExecutor(default_backend=SandboxMode.LOCAL)
 
-    def fake_describe(mode):
+    def fake_describe(mode, context=None, backend=None):
         if mode == SandboxMode.DOCKER:
             return {
                 "backend": "docker",

--- a/ts_agents/tools/executor.py
+++ b/ts_agents/tools/executor.py
@@ -77,6 +77,10 @@ def _first_nonempty_line(*chunks: str) -> Optional[str]:
     return None
 
 
+def _docker_image_name() -> str:
+    return os.environ.get("TS_AGENTS_DOCKER_IMAGE", "ts-agents-sandbox:latest")
+
+
 def describe_sandbox_backend(mode: Union["SandboxMode", str]) -> Dict[str, Any]:
     """Return a structured readiness probe for one sandbox backend."""
     sandbox_mode = _coerce_sandbox_mode(mode)
@@ -137,10 +141,48 @@ def describe_sandbox_backend(mode: Union["SandboxMode", str]) -> Dict[str, Any]:
             status["suggested_fix"] = "Start Docker and retry, or run with --sandbox local."
             return status
 
+        image = _docker_image_name()
+        try:
+            image_probe = subprocess.run(
+                ["docker", "image", "inspect", image, "--format", "{{.Id}}"],
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+        except Exception as exc:
+            status["available"] = False
+            status["reason"] = f"Docker image probe failed: {exc}"
+            status["suggested_fix"] = (
+                f"Build or pull '{image}', set TS_AGENTS_DOCKER_IMAGE to an available image, "
+                "or run with --sandbox local."
+            )
+            status["details"] = {
+                "docker_path": docker_path,
+                "server_version": probe.stdout.strip() or None,
+                "image": image,
+            }
+            return status
+
+        if image_probe.returncode != 0:
+            status["available"] = False
+            status["reason"] = f"Docker image '{image}' is not available locally."
+            status["suggested_fix"] = (
+                f"Build or pull '{image}', set TS_AGENTS_DOCKER_IMAGE to an available image, "
+                "or run with --sandbox local."
+            )
+            status["details"] = {
+                "docker_path": docker_path,
+                "server_version": probe.stdout.strip() or None,
+                "image": image,
+                "image_probe_error": _first_nonempty_line(image_probe.stderr, image_probe.stdout),
+            }
+            return status
+
         status["details"] = {
             "docker_path": docker_path,
             "server_version": probe.stdout.strip() or None,
-            "image": os.environ.get("TS_AGENTS_DOCKER_IMAGE", "ts-agents-sandbox:latest"),
+            "image": image,
+            "image_id": image_probe.stdout.strip() or None,
         }
         return status
 

--- a/ts_agents/tools/executor.py
+++ b/ts_agents/tools/executor.py
@@ -77,11 +77,26 @@ def _first_nonempty_line(*chunks: str) -> Optional[str]:
     return None
 
 
-def _docker_image_name() -> str:
-    return os.environ.get("TS_AGENTS_DOCKER_IMAGE", "ts-agents-sandbox:latest")
+def _docker_image_name(
+    *,
+    context: Optional["ExecutionContext"] = None,
+    backend: Optional["ExecutorBackend"] = None,
+) -> str:
+    """Resolve the Docker image using the same precedence as execution."""
+    return (
+        getattr(context, "docker_image", None)
+        or os.environ.get("TS_AGENTS_DOCKER_IMAGE")
+        or getattr(backend, "image", None)
+        or "ts-agents-sandbox:latest"
+    )
 
 
-def describe_sandbox_backend(mode: Union["SandboxMode", str]) -> Dict[str, Any]:
+def describe_sandbox_backend(
+    mode: Union["SandboxMode", str],
+    *,
+    context: Optional["ExecutionContext"] = None,
+    backend: Optional["ExecutorBackend"] = None,
+) -> Dict[str, Any]:
     """Return a structured readiness probe for one sandbox backend."""
     sandbox_mode = _coerce_sandbox_mode(mode)
     requirements = {
@@ -141,7 +156,7 @@ def describe_sandbox_backend(mode: Union["SandboxMode", str]) -> Dict[str, Any]:
             status["suggested_fix"] = "Start Docker and retry, or run with --sandbox local."
             return status
 
-        image = _docker_image_name()
+        image = _docker_image_name(context=context, backend=backend)
         try:
             image_probe = subprocess.run(
                 ["docker", "image", "inspect", image, "--format", "{{.Id}}"],
@@ -832,11 +847,7 @@ class DockerBackend(ExecutorBackend):
                 metadata={"tool_name": tool_name, "backend": "docker"},
             )
 
-        image = (
-            context.docker_image
-            or os.environ.get("TS_AGENTS_DOCKER_IMAGE")
-            or self.image
-        )
+        image = _docker_image_name(context=context, backend=self)
         timeout_s = context.timeout_seconds or int(os.environ.get("TS_AGENTS_DOCKER_TIMEOUT", "300"))
 
         # Resource defaults (best-effort; Docker may enforce its own limits)
@@ -1806,8 +1817,12 @@ class ToolExecutor:
         # Get execution backend
         requested_backend = context.sandbox_mode
         actual_backend = context.sandbox_mode
-        requested_status = describe_sandbox_backend(requested_backend)
         backend = self.backends.get(requested_backend)
+        requested_status = describe_sandbox_backend(
+            requested_backend,
+            context=context,
+            backend=backend,
+        )
         fallback_backend = context.fallback_backend or SandboxMode.LOCAL
 
         if backend is None or not requested_status["available"] or not backend.is_available():
@@ -1839,8 +1854,12 @@ class ToolExecutor:
                     },
                 )
 
-            fallback_status = describe_sandbox_backend(fallback_backend)
             backend = self.backends.get(fallback_backend)
+            fallback_status = describe_sandbox_backend(
+                fallback_backend,
+                context=context,
+                backend=backend,
+            )
             if backend is None or not fallback_status["available"] or not backend.is_available():
                 return ExecutionResult(
                     status=ExecutionStatus.FAILED,

--- a/ts_agents/workflows/executor.py
+++ b/ts_agents/workflows/executor.py
@@ -281,8 +281,12 @@ class WorkflowExecutor:
 
         requested_backend = context.sandbox_mode
         actual_backend = context.sandbox_mode
-        requested_status = describe_sandbox_backend(requested_backend)
         backend = self.backends.get(requested_backend)
+        requested_status = describe_sandbox_backend(
+            requested_backend,
+            context=context,
+            backend=backend,
+        )
         fallback_backend = context.fallback_backend or SandboxMode.LOCAL
 
         if backend is None or not requested_status["available"] or not backend.is_available():
@@ -314,8 +318,12 @@ class WorkflowExecutor:
                     },
                 )
 
-            fallback_status = describe_sandbox_backend(fallback_backend)
             backend = self.backends.get(fallback_backend)
+            fallback_status = describe_sandbox_backend(
+                fallback_backend,
+                context=context,
+                backend=backend,
+            )
             if backend is None or not fallback_status["available"] or not backend.is_available():
                 return ExecutionResult(
                     status=ExecutionStatus.FAILED,


### PR DESCRIPTION
Closes #73

## Summary
- include Docker image presence in sandbox readiness probing instead of only checking the Docker CLI and daemon
- return a clear missing-image reason and suggested fix from `sandbox doctor docker`
- let `--allow-fallback` engage when Docker is configured but the sandbox image is missing locally

## Behavior Changes
- `ts-agents sandbox doctor docker --json` now reports `available: false` when the configured image is absent
- Docker tool/workflow requests now fail early with `backend_unavailable` instead of a later Docker runtime computation error in this scenario
- Docker requests with `--allow-fallback --fallback-backend local` now fall back cleanly when the image is missing

## Tests
- `uv run python -m pytest -q tests/cli/test_sandbox.py tests/tools/test_executor.py`
- `uv run python -m pytest -q tests/cli/test_workflows.py -k sandbox`

## Manual Verification
- `uv run ts-agents sandbox doctor docker --json`
- `uv run ts-agents tool run describe_series --param series=[1,2,3,4] --sandbox docker --json`
- `uv run ts-agents tool run describe_series --param series=[1,2,3,4] --sandbox docker --allow-fallback --fallback-backend local --json`
- `uv run ts-agents workflow run inspect-series --input-json '{"series":[1,2,3,4]}' --sandbox docker --allow-fallback --fallback-backend local --json`

## Risks
- Docker readiness is now stricter and requires the image to exist locally before the backend is considered available, which matches the current local-build workflow and fallback contract
