### PR TITLE
Align autonomy docs and metadata before launch post

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,18 @@
 [![Python](https://img.shields.io/badge/python-3.11--3.13-3776AB)](#installation)
 [![License](https://img.shields.io/badge/license-MIT-2EA44F)](https://github.com/fnauman/ts-agents/blob/main/LICENSE)
 
-`ts-agents` provides time-series skills, workflow contracts, and sandboxes for
-agentic workflows.
+`ts-agents` is a CLI toolkit for **long-running autonomous agentic workflows**
+on time-series data. It gives agent runtimes a stable, machine-readable surface
+so a model can bootstrap, discover what's available, execute real work, and
+produce inspectable artifacts — without hand-written glue code per project.
 
 It is built around:
-- a stable CLI contract for discovery and execution (`ts-agents workflow ...`, `ts-agents tool ...`)
-- inspectable artifacts instead of chat-only outputs (plots, JSON, reports)
-- reusable skills that encode time-series workflow guidance
-- optional sandboxes for safer, reproducible execution (`local`, `subprocess`, `docker`, `daytona`, `modal`)
+- a stable CLI contract for bootstrap, discovery, and execution (`ts-agents capabilities`, `ts-agents workflow ...`, `ts-agents tool ...`)
+- strict JSON envelopes with `schema_version`, typed exit codes, top-level `quality_status`/`degraded`/`requires_review`, and nested workflow `result.status`/`result.data.quality_flags`
+- run lifecycle metadata: generated run IDs, `run_manifest.json`, non-clobbering default output directories, and `--resume` / `--overwrite` semantics
+- inspectable artifacts instead of chat-only outputs (plots as `ArtifactRef` files, JSON payloads, Markdown reports)
+- reusable skills that encode time-series workflow guidance as install-agnostic command templates
+- optional sandboxes for safer, reproducible execution (`local`, `subprocess`, `docker`, `daytona`, `modal`) with readiness probes and explicit fallback flags
 - optional adapters on top, including Gradio and built-in agent entrypoints
 
 It ships with three first-class workflows:
@@ -32,6 +36,7 @@ separately and are not part of the published wheel.
 ## Table of Contents
 
 - [Choose your path](#choose-your-path)
+- [For autonomous agents](#for-autonomous-agents)
 - [Why ts-agents instead of using statsforecast/sktime/aeon directly?](#why-ts-agents-instead-of-using-statsforecastsktimeaeon-directly)
 - [Design principles](#design-principles)
 - [Quickstart](#quickstart)
@@ -99,6 +104,92 @@ Configure `HOST`, `PORT`, `GRADIO_SHARE`, `TS_AGENTS_ENABLE_AGENT`,
 `TS_AGENTS_AGENT_TYPE`, `TS_AGENTS_PERSIST_SESSIONS`, and
 `TS_AGENTS_UI_TITLE` before launch if you need non-default behavior.
 
+## For Autonomous Agents
+
+`ts-agents` is designed so an autonomous agent can bootstrap itself, plan, and
+run multi-step time-series work against a stable contract — even across long,
+multi-turn sessions.
+
+### 1. Bootstrap with one command
+
+```bash
+ts-agents capabilities --json
+```
+
+Returns the full agent-facing surface: available workflows, tools, sandboxes,
+workflow discovery metadata, the current `install_profile` block, and
+status-contract guidance. Use this as the first call of any new agent session.
+
+### 2. Discover execution metadata before running anything
+
+```bash
+ts-agents workflow show forecast-series --json
+ts-agents tool show forecast_theta_with_data --json
+```
+
+Both `show` commands return `cli_templates`, `source_options`, `global_options`,
+`status_contract`, `default_output_behavior`, required extras, availability in
+the current environment, input modes, and artifact behavior. Agents can plan
+commands from this metadata rather than guessing flags.
+
+### 3. Strict machine-readable envelopes
+
+Every `--json` response is:
+
+- wrapped in a stable envelope with `schema_version: "1.0"`
+- strict JSON (no raw `NaN`/`Infinity`, `allow_nan=False`)
+- accompanied by typed exit codes for validation, dependency, permission, and
+  timeout errors — so agents can branch on failure mode instead of parsing
+  prose
+- tagged with top-level `quality_status`, `degraded`, and `requires_review`,
+  while workflow payloads expose `result.status` and
+  `result.data.quality_flags` for workflow-specific review signals
+
+### 4. Run lifecycle and provenance
+
+Workflow runs produce:
+
+- a generated run ID and run-scoped output directory under `outputs/<workflow>/<run-id>/`
+- a `run_manifest.json` capturing inputs, parameters, execution backend
+  metadata, and emitted artifacts
+- absolute paths on every `ArtifactRef` so an agent can materialize files from
+  any working directory
+- non-clobbering defaults, plus `--overwrite` / `--resume` semantics for retry
+  loops and long sessions
+
+### 5. Artifacts over chat
+
+Tool/workflow outputs are written to real files (PNG plots, JSON, CSV,
+Markdown reports) and returned as `ArtifactRef` entries. Chat is the control
+plane; the files are the product — they can be inspected, diffed, cached, and
+fed into the next step by the agent.
+
+### 6. Sandbox parity and explicit fallback
+
+```bash
+ts-agents sandbox list
+ts-agents sandbox doctor docker --json
+ts-agents workflow run inspect-series \
+  --input-json '{"series":[1,2,3,4]}' \
+  --sandbox docker --allow-fallback --fallback-backend local
+```
+
+`sandbox doctor` probes readiness (including Docker image presence). Docker,
+Daytona, and Modal all stage workflow artifacts back to the host output
+directory so `result.artifacts[*].path` and `result.data.output_dir` are
+always host-accessible. Fallback is explicit — the executor refuses to silently
+switch backends unless `--allow-fallback` is passed.
+
+### 7. Skills as install-agnostic command templates
+
+```bash
+ts-agents skills list
+ts-agents skills show forecasting --json
+```
+
+Skill catalogs export normalized `ts-agents ...` command templates with no
+checkout-specific prefixes, so agents can copy them verbatim into tool calls.
+
 ## Why ts-agents Instead of Using statsforecast/sktime/aeon Directly?
 
 Those libraries are excellent algorithm/toolkit layers, and `ts-agents`
@@ -117,11 +208,13 @@ Use `ts-agents` when you want:
 
 ## Design Principles
 
-- **CLI as the stable contract**: `ts-agents` is the primary interface for automation and reproducibility.
+- **CLI as the stable contract**: `ts-agents` is the primary interface for automation and reproducibility. Autonomous agents plan against `capabilities`, `workflow show`, and `tool show` instead of hardcoded knowledge.
+- **Strict machine envelopes**: `--json` output is versioned, strict, and typed — with status, quality flags, and exit codes — so agents can branch on failure mode rather than parsing prose.
 - **Framework adapters, not framework lock-in**: LangChain/deep-agent wrappers are convenience layers over the same tool registry.
 - **Artifacts over chat**: tools produce inspectable files (plots, JSON, reports), and agents return summaries plus paths.
+- **Run lifecycle as first-class metadata**: every workflow run gets a run ID, a `run_manifest.json`, and non-clobbering defaults — so long, multi-turn sessions remain reproducible and resumable.
 - **Swappable front-ends**: CLI agents, custom agents, and Gradio are interfaces around the same core tools.
-- **Sandboxed execution**: backends can isolate dependencies and scale heavier workloads.
+- **Sandboxed execution with explicit fallback**: backends isolate dependencies and scale heavier workloads; the executor never silently downgrades isolation.
 
 Canonical design doc:
 - `docs/philosophy.qmd`

--- a/docs/index.qmd
+++ b/docs/index.qmd
@@ -2,13 +2,39 @@
 title: "ts-agents docs"
 ---
 
-`ts-agents` is a CLI-first toolkit for time-series analysis and agent
-automation. It wraps statistical forecasting methods, sandboxed code
-execution, and LLM-driven agents behind a stable workflow/tool contract so you
-can go from raw data to evaluated artifacts without writing glue code.
+`ts-agents` is a CLI toolkit for **long-running autonomous agentic workflows**
+on time-series data. It gives agent runtimes a stable, machine-readable surface
+so a model can bootstrap, discover what's available, execute real work, and
+produce inspectable artifacts — without hand-written glue code per project.
 
-These docs capture the project's durable design choices so interfaces can evolve
-without rewriting the core toolchain.
+It wraps statistical forecasting methods, sandboxed code execution, and
+LLM-driven agents behind a stable workflow/tool contract so you can go from
+raw data to evaluated artifacts without writing glue code. These docs capture
+the project's durable design choices so interfaces can evolve without
+rewriting the core toolchain.
+
+## Why Autonomous Agents Like It
+
+- **Bootstrap with one call:** `ts-agents capabilities --json` returns the full
+  agent-facing bootstrap surface (workflows, tools, sandboxes, `install_profile`,
+  status-contract guidance).
+- **Discover before acting:** `workflow show --json` / `tool show --json`
+  expose `cli_templates`, `source_options`, `global_options`,
+  `default_output_behavior`, required extras, and availability in the current
+  environment.
+- **Strict machine envelopes:** every `--json` response carries
+  `schema_version: "1.0"`, strict JSON (no raw `NaN`), and typed exit codes for
+  validation / dependency / permission / timeout failures.
+- **Quality signals:** workflow payloads expose `result.status`
+  (`ok` / `degraded`) and `result.data.quality_flags`, while the CLI envelope exposes top-level
+  `quality_status`, `degraded`, and `requires_review`.
+- **Run lifecycle metadata:** generated run IDs, `run_manifest.json`, and
+  non-clobbering default output directories with `--overwrite` / `--resume`
+  semantics — so long multi-turn sessions remain reproducible and resumable.
+- **Sandbox parity + explicit fallback:** `local`, `subprocess`, `docker`,
+  `daytona`, and `modal` all stage workflow artifacts back to the host output
+  directory; `sandbox doctor` probes readiness; the executor never silently
+  downgrades isolation.
 
 ## Get Started
 
@@ -20,7 +46,7 @@ without rewriting the core toolchain.
 
 - [Skills Guide](skills-guide.qmd) — using, customizing, and creating skills
 - [Evaluation](evaluation.qmd) — benchmark evidence and rerun instructions
-- [Design](philosophy.qmd) — why the project is structured around a stable CLI contract
+- [Design](philosophy.qmd) — why the project is structured around a stable CLI contract for agents
 - [Distribution](distribution.qmd) — packaging, release, and publishing workflow
 
 ---

--- a/docs/philosophy.qmd
+++ b/docs/philosophy.qmd
@@ -4,12 +4,15 @@ title: "Project Philosophy"
 
 ## Scope
 
-`ts-agents` aims to be a practical "personal assistant data scientist" workbench
-for time-series tasks: fast, repeatable analysis with inspectable outputs.
+`ts-agents` aims to be a CLI toolkit that lets **autonomous agents** do real,
+reproducible time-series work over long, multi-turn sessions. The same surface
+doubles as a practical "personal assistant data scientist" workbench for
+humans: fast, repeatable analysis with inspectable outputs.
 
 It is not intended to be a monolithic end-user GUI product, and it is not
-"just an agent framework." The durable value is in tool contracts, domain
-priors, and reproducible execution.
+"just an agent framework." The durable value is in machine-readable tool
+contracts, domain priors, and reproducible execution that outlives any
+specific agent runtime.
 
 ## Core Principles
 
@@ -22,7 +25,41 @@ Why:
 
 - easy scripting and CI integration
 - easy debugging from command/log/artifact traces
-- easier harness swaps (Codex, Claude Code, custom agents)
+- easier harness swaps (Codex, Claude Code, custom agents) — the CLI outlives
+  the agent runtime
+
+### 1b. Machine-Readable Envelope For Autonomous Agents
+
+`--json` output is versioned (`schema_version`), strict (no raw `NaN`), and
+typed. CLI envelopes carry top-level `quality_status`, `degraded`, and
+`requires_review`; workflow payloads carry `result.status` and
+`result.data.quality_flags`. Exit codes are typed for validation, dependency,
+permission, and timeout failures.
+
+`ts-agents capabilities --json`, `workflow show --json`, and `tool show --json`
+are the agent bootstrap and discovery surface: they expose `cli_templates`,
+`source_options`, `global_options`, `status_contract`, and
+`default_output_behavior` so an agent can plan commands from metadata rather
+than hardcoded knowledge.
+
+Why:
+
+- agents can branch on failure mode instead of parsing prose
+- bootstrap and discovery are a single round-trip
+- new agent runtimes can integrate without code changes in `ts-agents`
+
+### 1c. Run Lifecycle As First-Class Metadata
+
+Every workflow run gets a generated run ID, a run-scoped directory under
+`outputs/<workflow>/<run-id>/`, a `run_manifest.json` capturing inputs/params/
+execution backend metadata/artifacts, and non-clobbering defaults with explicit
+`--overwrite` / `--resume` semantics.
+
+Why:
+
+- long autonomous sessions remain reproducible and resumable
+- retry loops don't corrupt previous outputs
+- downstream steps can materialize artifacts from any working directory
 
 ### 2. Framework Adapters, Not Framework Lock-In
 

--- a/docs/quickstart.qmd
+++ b/docs/quickstart.qmd
@@ -30,6 +30,33 @@ and a dependency-light `seasonal_naive` forecast baseline. Use
 `ts-agents[recommended]` or a source checkout with `uv sync` for the full
 three-workflow experience.
 
+## Bootstrap for autonomous agents
+
+If you are wiring `ts-agents` into an agent runtime, make these three calls
+first — they tell the agent exactly what is available in the current
+environment:
+
+```bash
+# 1. Top-level capabilities: workflows, tools, sandboxes, install_profile
+ts-agents capabilities --json
+
+# 2. Per-workflow execution metadata: CLI templates, options, status contract
+ts-agents workflow show forecast-series --json
+ts-agents workflow show inspect-series --json
+ts-agents workflow show activity-recognition --json
+
+# 3. Sandbox readiness for isolated execution
+ts-agents sandbox list
+ts-agents sandbox doctor local --json
+```
+
+Agents should plan commands from `cli_templates` in the `workflow show`
+response, watch the top-level `quality_status` / `degraded` /
+`requires_review` fields on every run, inspect workflow-level
+`result.status` / `result.data.quality_flags` for partial-success details, and
+read `run_manifest.json` inside the workflow output directory to enumerate
+artifacts.
+
 ## First run (base install, no LLM required)
 
 These commands work immediately with `python -m pip install ts-agents` — no API

--- a/tests/cli/test_sandbox.py
+++ b/tests/cli/test_sandbox.py
@@ -25,9 +25,15 @@ def test_capabilities_json_returns_bootstrap_surface(capsys):
     assert payload["command"] == "capabilities"
     assert "entrypoints" in payload["result"]
     assert "status_contract" in payload["result"]
+    assert "install_profile" in payload["result"]
     assert "workflows" in payload["result"]
     assert "tools" in payload["result"]
     assert "sandboxes" in payload["result"]
+    install_profile = payload["result"]["install_profile"]
+    assert install_profile["package"] == "ts-agents"
+    assert "current_profile" in install_profile
+    assert install_profile["recommended_install"] == "ts-agents[recommended]"
+    assert "forecasting" in install_profile["extras"]
 
 
 def test_sandbox_doctor_local_json_returns_backend_status(capsys):

--- a/tests/cli/test_workflows.py
+++ b/tests/cli/test_workflows.py
@@ -114,6 +114,13 @@ def test_workflow_run_inspect_series_accepts_stdin_json(monkeypatch, capsys, tmp
     manifest_payload = json.loads((output_dir / "run_manifest.json").read_text())
     manifest_artifact_paths = {artifact["path"] for artifact in manifest_payload["artifacts"]}
     assert str(output_dir / "run_manifest.json") in manifest_artifact_paths
+    assert payload["result"]["data"]["execution"]["backend_requested"] == "local"
+    assert payload["result"]["data"]["execution"]["backend_actual"] == "local"
+    assert payload["result"]["data"]["run"]["execution"]["fallback_used"] is False
+    assert manifest_payload["execution"]["backend_requested"] == "local"
+    assert manifest_payload["execution"]["backend_actual"] == "local"
+    assert manifest_payload["execution"]["fallback_allowed"] is False
+    assert manifest_payload["execution"]["fallback_used"] is False
     assert payload["result"]["data"]["autocorrelation"]["max_lag"] == 4
     assert payload["result"]["data"]["autocorrelation"]["requested_max_lag"] == 8
 

--- a/tests/cli/test_workflows.py
+++ b/tests/cli/test_workflows.py
@@ -125,6 +125,42 @@ def test_workflow_run_inspect_series_accepts_stdin_json(monkeypatch, capsys, tmp
     assert payload["result"]["data"]["autocorrelation"]["requested_max_lag"] == 8
 
 
+def test_workflow_run_manifest_sync_write_failure_does_not_fail_cli(monkeypatch, capsys, tmp_path):
+    import importlib
+
+    cli_main = importlib.import_module("ts_agents.cli.main")
+    original_write_output = cli_main.write_output
+
+    def flaky_write_output(content, path):
+        if str(path).endswith("run_manifest.json"):
+            raise OSError("disk full")
+        return original_write_output(content, path)
+
+    monkeypatch.setattr(cli_main, "write_output", flaky_write_output)
+
+    output_dir = tmp_path / "inspect"
+    code = cli_main.run(
+        [
+            "workflow",
+            "run",
+            "inspect-series",
+            "--input-json",
+            '{"series":[1,2,3,4,5]}',
+            "--output-dir",
+            str(output_dir),
+            "--skip-plots",
+            "--json",
+        ]
+    )
+
+    assert code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["ok"] is True
+    assert payload["result"]["data"]["execution"]["backend_requested"] == "local"
+    assert payload["result"]["data"]["execution"]["backend_actual"] == "local"
+    assert (output_dir / "run_manifest.json").exists()
+
+
 def test_workflow_run_inspect_series_supports_subprocess_sandbox(capsys, tmp_path):
     output_dir = tmp_path / "inspect_subprocess"
     code = run(

--- a/ts_agents/cli/main.py
+++ b/ts_agents/cli/main.py
@@ -676,7 +676,10 @@ def _synchronize_workflow_manifest(result: Any, execution: Any) -> None:
         manifest_payload["execution"] = dict(execution_metadata)
 
     payload_text = render_output(to_jsonable(manifest_payload), json_output=True)
-    write_output(payload_text, str(manifest_path))
+    try:
+        write_output(payload_text, str(manifest_path))
+    except OSError:
+        return
 
 
 def _quality_payload(result: Any) -> Tuple[Optional[str], Optional[bool], Optional[bool]]:

--- a/ts_agents/cli/main.py
+++ b/ts_agents/cli/main.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 from difflib import get_close_matches
 from functools import partial
+from importlib.util import find_spec
 import json
 import os
 from pathlib import Path
@@ -24,6 +25,65 @@ from .output import (
     to_jsonable,
     write_output,
 )
+
+
+_INSTALL_EXTRA_METADATA: Dict[str, Dict[str, Any]] = {
+    "viz": {
+        "install_spec": "ts-agents[viz]",
+        "dependencies": ["matplotlib"],
+        "description": "Plot artifacts and visualization helpers.",
+    },
+    "ui": {
+        "install_spec": "ts-agents[ui]",
+        "dependencies": ["gradio", "matplotlib"],
+        "description": "Gradio UI and hosted/manual demo entrypoints.",
+    },
+    "agents": {
+        "install_spec": "ts-agents[agents]",
+        "dependencies": ["langchain", "langchain_core", "langchain_openai"],
+        "description": "Built-in agent entrypoints and orchestration adapters.",
+    },
+    "decomposition": {
+        "install_spec": "ts-agents[decomposition]",
+        "dependencies": ["statsmodels"],
+        "description": "Statsmodels-backed decomposition methods.",
+    },
+    "forecasting": {
+        "install_spec": "ts-agents[forecasting]",
+        "dependencies": ["statsforecast"],
+        "description": "StatsForecast-backed ARIMA/ETS/Theta forecasting methods.",
+    },
+    "patterns": {
+        "install_spec": "ts-agents[patterns]",
+        "dependencies": ["ruptures", "stumpy"],
+        "description": "Pattern, changepoint, and matrix-profile tooling.",
+    },
+    "classification": {
+        "install_spec": "ts-agents[classification]",
+        "dependencies": ["aeon", "sklearn"],
+        "description": "Activity-recognition and classifier evaluation workflows.",
+    },
+}
+
+_INSTALL_PROFILE_GROUPS: Dict[str, List[str]] = {
+    "recommended": [
+        "classification",
+        "ui",
+        "agents",
+        "viz",
+        "forecasting",
+        "decomposition",
+    ],
+    "all": [
+        "classification",
+        "ui",
+        "agents",
+        "viz",
+        "forecasting",
+        "decomposition",
+        "patterns",
+    ],
+}
 
 
 def _parse_bool(raw: str) -> bool:
@@ -48,6 +108,68 @@ class TSArgumentParser(argparse.ArgumentParser):
             partial(type(self), exit_on_error=self._ts_exit_on_error),
         )
         return super().add_subparsers(**kwargs)
+
+
+def _module_is_available(module_name: str) -> bool:
+    return find_spec(module_name) is not None
+
+
+def _detect_install_profile() -> Dict[str, Any]:
+    extras: Dict[str, Dict[str, Any]] = {}
+    active_extras: List[str] = []
+    for extra, metadata in _INSTALL_EXTRA_METADATA.items():
+        missing_dependencies = [
+            dependency
+            for dependency in metadata["dependencies"]
+            if not _module_is_available(dependency)
+        ]
+        available = not missing_dependencies
+        if available:
+            active_extras.append(extra)
+        extras[extra] = {
+            "install_spec": metadata["install_spec"],
+            "description": metadata["description"],
+            "available": available,
+            "missing_dependencies": missing_dependencies,
+        }
+
+    if all(extras[extra]["available"] for extra in _INSTALL_PROFILE_GROUPS["all"]):
+        current_profile = "all"
+    elif all(extras[extra]["available"] for extra in _INSTALL_PROFILE_GROUPS["recommended"]):
+        current_profile = "recommended"
+    elif active_extras:
+        current_profile = "custom"
+    else:
+        current_profile = "base"
+
+    return {
+        "package": "ts-agents",
+        "base_install": "ts-agents",
+        "current_profile": current_profile,
+        "recommended_install": "ts-agents[recommended]",
+        "all_features_install": "ts-agents[all]",
+        "active_extras": active_extras,
+        "profiles": {
+            "base": {
+                "install_spec": "ts-agents",
+                "description": (
+                    "CLI-first base install with discovery, inspect-series, and the "
+                    "seasonal_naive forecasting baseline."
+                ),
+            },
+            "recommended": {
+                "install_spec": "ts-agents[recommended]",
+                "description": "Demo-friendly profile covering the main workflow stack.",
+                "extras": list(_INSTALL_PROFILE_GROUPS["recommended"]),
+            },
+            "all": {
+                "install_spec": "ts-agents[all]",
+                "description": "Full optional feature set, including patterns tooling.",
+                "extras": list(_INSTALL_PROFILE_GROUPS["all"]),
+            },
+        },
+        "extras": extras,
+    }
 
 
 def _maybe_number(raw: str) -> Any:
@@ -476,6 +598,85 @@ def _execution_payload(execution: Any) -> Optional[CLIExecution]:
         duration_ms=getattr(execution, "duration_ms", None),
         metadata=metadata,
     )
+
+
+def _workflow_execution_metadata(execution: Any) -> Dict[str, Any]:
+    metadata = getattr(execution, "metadata", {}) or {}
+    backend_requested = metadata.get("backend_requested")
+    backend_actual = metadata.get("backend_actual") or metadata.get("backend")
+    execution_metadata = {
+        "backend_requested": backend_requested,
+        "backend_actual": backend_actual,
+        "fallback_allowed": metadata.get("fallback_allowed"),
+        "fallback_used": metadata.get("fallback_used"),
+        "fallback_backend": metadata.get("fallback_backend"),
+    }
+    return {key: value for key, value in execution_metadata.items() if value is not None}
+
+
+def _synchronize_workflow_manifest(result: Any, execution: Any) -> None:
+    if isinstance(result, dict):
+        data = result.get("data")
+        status = result.get("status")
+        summary = result.get("summary")
+        warnings = result.get("warnings") or []
+        artifacts = result.get("artifacts")
+        provenance = result.get("provenance")
+    else:
+        data = getattr(result, "data", None)
+        status = getattr(result, "status", None)
+        summary = getattr(result, "summary", None)
+        warnings = getattr(result, "warnings", []) or []
+        artifacts = getattr(result, "artifacts", None)
+        provenance = getattr(result, "provenance", None)
+
+    if not isinstance(data, dict):
+        return
+
+    execution_metadata = _workflow_execution_metadata(execution)
+    if execution_metadata:
+        data["execution"] = dict(execution_metadata)
+        run_metadata = data.get("run")
+        if isinstance(run_metadata, dict):
+            run_metadata["execution"] = dict(execution_metadata)
+
+    manifest_path_raw = data.get("manifest_path")
+    if not isinstance(manifest_path_raw, str):
+        return
+
+    manifest_path = Path(manifest_path_raw)
+    if not manifest_path.exists():
+        return
+
+    try:
+        manifest_payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return
+    if not isinstance(manifest_payload, dict):
+        return
+
+    if isinstance(status, str):
+        manifest_payload["status"] = status
+    if isinstance(summary, str):
+        manifest_payload["summary"] = summary
+    if isinstance(data.get("output_dir"), str):
+        manifest_payload["output_dir"] = data["output_dir"]
+    manifest_payload["manifest_path"] = str(manifest_path)
+    if isinstance(data.get("run_id"), str):
+        manifest_payload["run_id"] = data["run_id"]
+    if isinstance(data.get("source"), dict):
+        manifest_payload["source"] = to_jsonable(data["source"])
+    manifest_payload["warnings"] = to_jsonable(warnings)
+    manifest_payload["quality_flags"] = to_jsonable(data.get("quality_flags") or [])
+    if isinstance(artifacts, list):
+        manifest_payload["artifacts"] = to_jsonable(artifacts)
+    if provenance is not None:
+        manifest_payload["provenance"] = to_jsonable(provenance)
+    if execution_metadata:
+        manifest_payload["execution"] = dict(execution_metadata)
+
+    payload_text = render_output(to_jsonable(manifest_payload), json_output=True)
+    write_output(payload_text, str(manifest_path))
 
 
 def _quality_payload(result: Any) -> Tuple[Optional[str], Optional[bool], Optional[bool]]:
@@ -1758,6 +1959,7 @@ def _handle_capabilities_command(args: argparse.Namespace) -> Tuple[Any, str]:
     tools = ToolRegistry.list_all()
     available_tools = sum(1 for tool in tools if tool_availability(tool)["available"])
     tools_by_category = ToolRegistry.get_tools_for_category_summary()
+    install_profile = _detect_install_profile()
 
     result = {
         "entrypoints": {
@@ -1780,6 +1982,7 @@ def _handle_capabilities_command(args: argparse.Namespace) -> Tuple[Any, str]:
                 "ts-agents sandbox doctor <backend> --json",
             ],
         },
+        "install_profile": install_profile,
         "status_contract": _capabilities_status_contract(),
         "recommended_entrypoints": [
             "Start with `workflow list --json` for public workflows.",
@@ -1807,6 +2010,7 @@ def _handle_capabilities_command(args: argparse.Namespace) -> Tuple[Any, str]:
         "- Start with workflow discovery for public automation surfaces.",
         f"- Workflows: {len(workflows)}",
         f"- Tools: {len(tools)} total, {available_tools} currently available",
+        f"- Install profile: {install_profile['current_profile']}",
         f"- Default sandbox backend: {result['sandboxes']['default_backend']}",
     ]
     return result, "\n".join(lines)
@@ -2150,6 +2354,7 @@ def _handle_workflow_command(args: argparse.Namespace) -> Tuple[Any, Optional[st
             raise execution.error
         raise RuntimeError(execution.formatted_output or "Workflow execution failed")
 
+    _synchronize_workflow_manifest(execution.result, execution)
     return execution.result, execution.formatted_output or None
 
 


### PR DESCRIPTION
Closes #76

## Summary
- add a real `install_profile` block to `ts-agents capabilities --json`
- sync workflow execution backend metadata into workflow run payloads and `run_manifest.json`
- tighten the autonomous-agent docs so public claims use the exact shipped field names
- add focused CLI coverage for the new metadata

## Behavior Changes
- `ts-agents capabilities --json` now exposes `result.install_profile` with the detected current profile, active extras, and install specs for the base/recommended/all profiles
- successful workflow runs now copy execution backend metadata into `result.data.execution`, `result.data.run.execution`, and the persisted `run_manifest.json`
- README/docs now distinguish top-level `quality_status` / `degraded` / `requires_review` from workflow-level `result.status` / `result.data.quality_flags`
- the docs now describe `run_manifest.json` as carrying execution backend metadata rather than implying fields that were not actually persisted

## Tests
- `uv run python -m pytest -q tests/cli/test_sandbox.py tests/cli/test_workflows.py`
- `uv run ts-agents capabilities --json`
- `uv run ts-agents workflow run inspect-series --input-json '{"series":[1,2,3,4]}' --output-dir /tmp/ts-agents-post-alignment-inspect --overwrite --skip-plots --json`
- `uv run ts-agents workflow run inspect-series --input-json '{"series":[1,2,3,4]}' --sandbox docker --allow-fallback --fallback-backend local --output-dir /tmp/ts-agents-post-alignment-fallback --overwrite --skip-plots --json`
- `quarto render docs/index.qmd`
- `quarto render docs/philosophy.qmd`
- `quarto render docs/quickstart.qmd`

## Manifest / Profile Impacts
- adds a new machine-readable `install_profile` surface under `capabilities --json`
- extends persisted workflow manifests with execution backend metadata for provenance and public docs accuracy
- no dependency manifest changes

## Risks
- `install_profile.current_profile` is inferred from available optional dependency modules, so mixed/custom environments are reported as `custom` rather than pretending to know the original install command
- workflow manifests now include an additive `execution` field; callers should treat it as new metadata rather than a replacement for the top-level CLI `execution` envelope
