### PR TITLE
[codex] land docs consistency and exploration-first metadata follow-ups

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,15 @@ The goal of this file is to make coding agents effective and safe in this codeba
 uv sync
 ```
 
+Plain `uv sync` matches the base CLI-first install profile. Add extras as
+needed for optional surfaces:
+
+```bash
+uv sync --extra recommended
+uv sync --extra ui
+uv sync --all-extras
+```
+
 ### Inspect the CLI
 ```bash
 uv run ts-agents --help
@@ -21,6 +30,7 @@ uv run ts-agents --help
 
 ### Run the interactive UI
 ```bash
+uv sync --extra ui
 uv run ts-agents-ui
 ```
 

--- a/README.md
+++ b/README.md
@@ -64,9 +64,10 @@ ts-agents workflow run forecast-series --input-json '{"series":[1,2,3,4,5,6,7,8,
 
 Base install is guaranteed to support workflow discovery plus `inspect-series`.
 It also supports a light `seasonal_naive` forecasting baseline. Install
-`ts-agents[recommended]` (or use `uv sync` from a source checkout) for the full
-three-workflow experience, including ARIMA/ETS/Theta forecasting and
-`activity-recognition`.
+`ts-agents[recommended]` for the full three-workflow experience, including
+ARIMA/ETS/Theta forecasting and `activity-recognition`. From a source
+checkout, plain `uv sync` matches the base CLI-first install; use
+`uv sync --extra recommended` for the same recommended workflow stack.
 
 ### 2. Use the low-level CLI on bundled or custom data
 
@@ -92,7 +93,8 @@ ts-agents-ui
 ts-agents-hosted
 ```
 
-From a source checkout (`git clone ...` + `uv sync`), use the root wrappers:
+From a source checkout with UI dependencies synced (for example,
+`uv sync --extra ui` or `uv sync --extra recommended`), use the root wrappers:
 
 ```bash
 uv run python main.py
@@ -230,7 +232,7 @@ ts-agents workflow run inspect-series --input-json '{"series":[1,2,3,4]}'
 ts-agents workflow run forecast-series --input-json '{"series":[1,2,3,4,5,6,7,8,9,10]}' --horizon 3 --methods seasonal_naive
 
 # Full workflow stack from a source checkout
-uv sync
+uv sync --extra recommended
 uv run ts-agents workflow run forecast-series --input-json '{"series":[1,2,3,4,5,6,7,8,9,10]}' --horizon 3 --methods seasonal_naive,arima,theta
 uv run python data/make_synthetic_labeled_stream.py --scenario gait --seconds 40 --seed 1337 --out data/demo_labeled_stream.csv
 uv run ts-agents workflow run activity-recognition --input data/demo_labeled_stream.csv --label-col label --value-cols x,y,z
@@ -301,6 +303,8 @@ Install profiles:
 - `ts-agents[forecasting]`: unlocks ARIMA, ETS, and Theta for `forecast-series`
 - `ts-agents[classification]`: unlocks `activity-recognition`
 - `ts-agents[recommended]`: the documented three-workflow experience used in walkthroughs and demos
+- `source checkout + uv sync`: same base CLI-first profile as `ts-agents`
+- `source checkout + uv sync --extra recommended`: same recommended profile as `ts-agents[recommended]`
 
 Run the packaged entrypoints:
 
@@ -316,8 +320,8 @@ ts-agents-ui --help
 ts-agents-hosted
 ```
 
-If you are running from a source checkout with `uv sync`, prefix the CLI
-commands below with `uv run`.
+If you are running from a source checkout, prefix the CLI commands below with
+`uv run` after syncing the extras you need.
 
 Source checkout setup:
 
@@ -325,6 +329,15 @@ Source checkout setup:
 git clone https://github.com/fnauman/ts-agents.git
 cd ts-agents
 uv sync
+```
+
+Plain `uv sync` matches the base CLI-first install profile. Add extras as
+needed:
+
+```bash
+uv sync --extra recommended
+uv sync --extra ui
+uv sync --all-extras
 ```
 
 Local editable install from a source checkout:

--- a/demo/README.md
+++ b/demo/README.md
@@ -69,12 +69,24 @@ WISDM accelerometer subset (2 subjects, 6 activities, ~33 k rows).
 bash demo/run_demo_wisdm.sh
 ```
 
-Outputs (under `outputs/demo_wisdm/`):
+Outputs from the legacy shell script (under `outputs/demo_wisdm/`):
 
 - `window_selection.json`
 - `window_scores.png`
 - `eval.json`
 - `confusion_matrix.png`
+
+If you also want `report.md`, use the deprecated CLI alias directly:
+
+```bash
+uv run ts-agents demo window-classification --no-llm \
+  --no-generate \
+  --csv-path data/wisdm_subset.csv \
+  --output-dir outputs/demo_wisdm \
+  --report-path outputs/demo_wisdm/report.md
+```
+
+That compatibility path writes the same core artifacts plus `outputs/demo_wisdm/report.md`.
 
 ---
 
@@ -86,11 +98,17 @@ Compares forecasting methods on the MHD shearing-box dataset (`data/short_real.c
 bash demo/run_demo_forecasting.sh
 ```
 
+The legacy shell script overrides the raw CLI defaults and writes its artifacts to
+`outputs/demo_forecasting/`, including `forecasting_report.md`.
+
 Or via the deprecated compatibility alias:
 
 ```bash
 uv run ts-agents demo forecasting --no-llm
 ```
+
+The raw CLI alias defaults to `outputs/demo/` for workflow artifacts and
+`outputs/demo/forecasting_report.md` for the compatibility report.
 
 The CLI default method set is `arima,theta` for stable behavior on the tiny
 built-in test data. To include ETS, prefer a larger setup:
@@ -99,11 +117,16 @@ built-in test data. To include ETS, prefer a larger setup:
 uv run ts-agents demo forecasting --full-data --horizon 12 --methods arima,ets,theta --no-llm
 ```
 
-Outputs (under `outputs/demo_forecasting/`):
+Outputs from the raw CLI alias (under `outputs/demo/` by default):
 
 - `forecast_comparison.json`
-- `forecast_comparison.png`
+- `forecast.json`
+- `forecast.csv`
+- `report.md`
 - `forecasting_report.md`
+- `forecast_comparison.png` (when plotting is available)
+
+The legacy shell script writes the same artifact set under `outputs/demo_forecasting/`.
 
 ---
 

--- a/docs/cli-examples.qmd
+++ b/docs/cli-examples.qmd
@@ -7,7 +7,9 @@ current workflow/tool grammar rather than the deprecated compatibility aliases.
 
 Install notes:
 - `ts-agents`: workflow discovery, `inspect-series`, and `forecast-series --methods seasonal_naive`
-- `ts-agents[recommended]` or `uv sync`: full forecasting comparisons plus `activity-recognition`
+- `ts-agents[recommended]`: full forecasting comparisons plus `activity-recognition`
+- `source checkout + uv sync`: same base CLI-first profile as `ts-agents`
+- `source checkout + uv sync --extra recommended`: same recommended profile as `ts-agents[recommended]`
 
 ## Data discovery
 

--- a/docs/quickstart.qmd
+++ b/docs/quickstart.qmd
@@ -27,8 +27,9 @@ uv sync
 
 Base install gives you workflow discovery, `workflow show`, `inspect-series`,
 and a dependency-light `seasonal_naive` forecast baseline. Use
-`ts-agents[recommended]` or a source checkout with `uv sync` for the full
-three-workflow experience.
+`ts-agents[recommended]` for the full three-workflow experience. From a source
+checkout, plain `uv sync` matches the base CLI-first install; use
+`uv sync --extra recommended` for the same recommended workflow stack.
 
 ## Bootstrap for autonomous agents
 
@@ -91,7 +92,7 @@ Use this path when you want ARIMA/ETS/Theta forecasting comparisons plus
 `activity-recognition`.
 
 ```bash
-uv sync
+uv sync --extra recommended
 
 # Compare multiple forecasting baselines
 uv run ts-agents workflow run forecast-series \

--- a/docs/talks/ts_agents_talk.qmd
+++ b/docs/talks/ts_agents_talk.qmd
@@ -102,7 +102,7 @@ Add richer GUI interactions (artifact browser + job monitor + review UX) — but
 #### Quickstart
 
 ```bash
-uv sync
+uv sync --extra recommended
 uv run ts-agents workflow list
 uv run ts-agents tool list
 uv run ts-agents workflow run forecast-series \

--- a/docs/walkthroughs.qmd
+++ b/docs/walkthroughs.qmd
@@ -8,7 +8,8 @@ the workflow/tool grammar that new automation should prefer.
 
 Profile note:
 - Base install supports `inspect-series` plus a light `seasonal_naive` forecast baseline.
-- Use `ts-agents[recommended]` or `uv sync` for the full forecasting and activity-recognition walkthroughs below.
+- Use `ts-agents[recommended]` for the full forecasting and activity-recognition walkthroughs below.
+- From a source checkout, plain `uv sync` matches the base CLI-first profile; use `uv sync --extra recommended` for the same recommended workflow stack.
 
 ## Inspect a series {#inspect}
 
@@ -24,7 +25,7 @@ This single command:
 
 1. computes descriptive statistics
 2. estimates periodicity and autocorrelation
-3. writes a structured JSON summary
+3. writes a structured JSON summary plus a findings ledger
 4. writes a Markdown report and an autocorrelation plot
 
 ### 2. Interpret the outputs
@@ -33,7 +34,8 @@ All artifacts land in `outputs/inspect/` by default.
 
 | Artifact | What it tells you |
 |----------|-------------------|
-| `summary.json` | Stats, periodicity, autocorrelation, and recommended next steps |
+| `summary.json` | Stats, periodicity, autocorrelation, forecast recommendation, and recommended next steps |
+| `ledger.json` | Structured findings ledger for downstream agent/model-selection steps |
 | `autocorrelation.png` | Visual lag structure for the inspected series |
 | `report.md` | Markdown summary of the diagnostic run |
 

--- a/tests/cli/test_params.py
+++ b/tests/cli/test_params.py
@@ -422,6 +422,33 @@ def test_tool_show_json_reports_optional_backend_for_seasonal_naive(capsys):
     assert result["availability"]["optional_features"][0]["name"] == "statsforecast_backend"
 
 
+def test_tool_show_json_includes_prior_diagnostics(capsys):
+    code = run(["tool", "show", "forecast_arima", "--json"])
+
+    assert code == 0
+    payload = json.loads(capsys.readouterr().out)
+    prior_diagnostics = payload["result"]["prior_diagnostics"]
+    assert len(prior_diagnostics) == 2
+    assert prior_diagnostics[0]["kind"] == "workflow"
+    assert prior_diagnostics[0]["name"] == "inspect-series"
+    assert "Inspect period, lag structure" in prior_diagnostics[0]["reason"]
+    assert prior_diagnostics[1]["kind"] == "tool"
+    assert prior_diagnostics[1]["name"] == "detect_periodicity"
+    assert "Estimate season_length" in prior_diagnostics[1]["reason"]
+
+
+def test_tool_search_json_includes_prior_diagnostics_in_summary(capsys):
+    code = run(["tool", "search", "arima", "--json"])
+
+    assert code == 0
+    payload = json.loads(capsys.readouterr().out)
+    forecast_arima = next(
+        tool for tool in payload["result"]["tools"] if tool["name"] == "forecast_arima"
+    )
+    assert forecast_arima["prior_diagnostics"]
+    assert forecast_arima["prior_diagnostics"][0]["name"] == "inspect-series"
+
+
 def test_tool_show_text_reports_optional_backend_without_install_hint_when_backend_missing(
     monkeypatch,
     capsys,

--- a/tests/cli/test_sandbox.py
+++ b/tests/cli/test_sandbox.py
@@ -36,6 +36,15 @@ def test_capabilities_json_returns_bootstrap_surface(capsys):
     assert "forecasting" in install_profile["extras"]
 
 
+def test_capabilities_text_reports_install_profile_on_its_own_line(capsys):
+    code = run(["capabilities"])
+
+    assert code == 0
+    output = capsys.readouterr().out
+    assert "- Tools:" in output
+    assert "\n- Install profile: " in output
+
+
 def test_sandbox_doctor_local_json_returns_backend_status(capsys):
     code = run(["sandbox", "doctor", "local", "--json"])
 

--- a/tests/cli/test_workflows.py
+++ b/tests/cli/test_workflows.py
@@ -106,13 +106,17 @@ def test_workflow_run_inspect_series_accepts_stdin_json(monkeypatch, capsys, tmp
     assert payload["result"]["data"]["manifest_path"] == str(output_dir / "run_manifest.json")
     assert (output_dir / "run_manifest.json").exists()
     assert (output_dir / "summary.json").exists()
+    assert (output_dir / "ledger.json").exists()
     assert (output_dir / "report.md").exists()
+    assert payload["result"]["data"]["forecast_recommendation"]["choice"]
     artifact_paths = {artifact["path"] for artifact in payload["result"]["artifacts"]}
     assert str(output_dir / "summary.json") in artifact_paths
+    assert str(output_dir / "ledger.json") in artifact_paths
     assert str(output_dir / "report.md") in artifact_paths
     assert str(output_dir / "run_manifest.json") in artifact_paths
     manifest_payload = json.loads((output_dir / "run_manifest.json").read_text())
     manifest_artifact_paths = {artifact["path"] for artifact in manifest_payload["artifacts"]}
+    assert str(output_dir / "ledger.json") in manifest_artifact_paths
     assert str(output_dir / "run_manifest.json") in manifest_artifact_paths
     assert payload["result"]["data"]["execution"]["backend_requested"] == "local"
     assert payload["result"]["data"]["execution"]["backend_actual"] == "local"
@@ -187,6 +191,7 @@ def test_workflow_run_inspect_series_supports_subprocess_sandbox(capsys, tmp_pat
     assert payload["result"]["data"]["output_dir"] == str(output_dir.resolve())
     assert payload["result"]["data"]["manifest_path"] == str((output_dir / "run_manifest.json").resolve())
     assert (output_dir / "summary.json").exists()
+    assert (output_dir / "ledger.json").exists()
     assert (output_dir / "report.md").exists()
 
 

--- a/tests/cli/test_workflows.py
+++ b/tests/cli/test_workflows.py
@@ -195,6 +195,42 @@ def test_workflow_run_inspect_series_supports_subprocess_sandbox(capsys, tmp_pat
     assert (output_dir / "report.md").exists()
 
 
+def test_workflow_run_inspect_series_restricts_recommendation_to_available_methods(
+    monkeypatch,
+    capsys,
+    tmp_path,
+):
+    import ts_agents.workflows.inspect as inspect_mod
+
+    monkeypatch.setattr(inspect_mod, "_available_forecasting_methods", lambda: ["seasonal_naive"])
+
+    output_dir = tmp_path / "inspect_base_profile"
+    code = run(
+        [
+            "workflow",
+            "run",
+            "inspect-series",
+            "--input-json",
+            '{"series":[1,2,3,4,5,6,7,8,9,10,11,12]}',
+            "--output-dir",
+            str(output_dir),
+            "--skip-plots",
+            "--json",
+        ]
+    )
+
+    assert code == 0
+    payload = json.loads(capsys.readouterr().out)
+    recommendation = payload["result"]["data"]["forecast_recommendation"]
+    assert recommendation["choice"] == "seasonal_naive"
+    assert recommendation["alternatives"] == []
+    ledger_payload = json.loads((output_dir / "ledger.json").read_text())
+    recommendation_entry = next(
+        entry for entry in ledger_payload["entries"] if entry["key"] == "forecasting_method"
+    )
+    assert recommendation_entry["value"] == "seasonal_naive"
+
+
 def test_workflow_run_generates_run_scoped_output_dir_by_default(monkeypatch, capsys, tmp_path):
     monkeypatch.chdir(tmp_path)
 

--- a/tests/core/test_recommendations.py
+++ b/tests/core/test_recommendations.py
@@ -1,0 +1,77 @@
+import pytest
+
+from ts_agents.core.recommendations import recommend_forecasting_method
+
+
+@pytest.mark.parametrize(
+    ("stats", "periodicity", "acf", "available_methods", "expected_choice"),
+    [
+        (
+            {"length": 96, "std": 1.2},
+            {"dominant_period": 24.0, "confidence": 0.72},
+            [1.0, 0.31, 0.12],
+            ["seasonal_naive", "theta", "ets", "arima"],
+            "seasonal_naive",
+        ),
+        (
+            {"length": 48, "std": 0.8},
+            {"dominant_period": 0.0, "confidence": 0.05},
+            [1.0, 0.86, 0.55],
+            ["theta", "arima"],
+            "theta",
+        ),
+        (
+            {"length": 18, "std": 0.4},
+            {"dominant_period": 12.0, "confidence": 0.4},
+            [1.0, 0.2, 0.1],
+            ["seasonal_naive"],
+            "seasonal_naive",
+        ),
+    ],
+)
+def test_recommend_forecasting_method_selects_expected_baseline(
+    stats,
+    periodicity,
+    acf,
+    available_methods,
+    expected_choice,
+):
+    recommendation = recommend_forecasting_method(
+        stats=stats,
+        periodicity=periodicity,
+        acf=acf,
+        available_methods=available_methods,
+    )
+
+    assert recommendation.choice == expected_choice
+    assert recommendation.confidence is not None
+    assert 0.0 < recommendation.confidence <= 0.95
+    assert recommendation.rationale
+
+
+def test_recommend_forecasting_method_marks_met_and_missing_preconditions():
+    recommendation = recommend_forecasting_method(
+        stats={"length": 72, "std": 1.0},
+        periodicity={"dominant_period": 0.0, "confidence": 0.03},
+        acf=[1.0, 0.77, 0.42],
+        available_methods=["theta", "arima"],
+    )
+
+    assert recommendation.choice == "theta"
+    assert "strong_short_lag_dependence" in recommendation.preconditions_met
+    assert "seasonality_detected" in recommendation.preconditions_missing
+    assert "arima" in recommendation.alternatives
+
+
+def test_recommend_forecasting_method_reports_low_information_series():
+    recommendation = recommend_forecasting_method(
+        stats={"length": 12, "std": 0.0},
+        periodicity={"dominant_period": 0.0, "confidence": 0.0},
+        acf=[1.0],
+        available_methods=["seasonal_naive"],
+    )
+
+    assert recommendation.choice == "seasonal_naive"
+    assert "series_has_variation" in recommendation.preconditions_missing
+    assert recommendation.confidence is not None
+    assert recommendation.confidence < 0.4

--- a/ts_agents/cli/main.py
+++ b/ts_agents/cli/main.py
@@ -1860,6 +1860,14 @@ def _tool_summary_dict(tool: Any) -> Dict[str, Any]:
         "availability": tool_availability(tool),
         "writes_artifacts": bool(tool.artifact_kinds),
         "artifact_kinds": list(tool.artifact_kinds),
+        "prior_diagnostics": [
+            {
+                "kind": hint.kind,
+                "name": hint.name,
+                "reason": hint.reason,
+            }
+            for hint in tool.prior_diagnostics
+        ],
     }
 
 
@@ -1911,6 +1919,14 @@ def _tool_detail_dict(tool: Any) -> Dict[str, Any]:
         "cli_templates": _tool_cli_templates(tool),
         "writes_artifacts": bool(tool.artifact_kinds),
         "artifact_kinds": list(tool.artifact_kinds),
+        "prior_diagnostics": [
+            {
+                "kind": hint.kind,
+                "name": hint.name,
+                "reason": hint.reason,
+            }
+            for hint in tool.prior_diagnostics
+        ],
         "status_contract": _tool_status_contract(tool),
         "resources": {
             "timeout_seconds": tool.timeout_seconds,
@@ -2099,6 +2115,10 @@ def _handle_tool_command(args: argparse.Namespace) -> Tuple[Any, str]:
             lines.append(f"Required extras: {', '.join(result['required_extras'])}")
         if install_hint:
             lines.append(f"Install hint: {install_hint}")
+        if result.get("prior_diagnostics"):
+            lines.append("Prior diagnostics:")
+            for hint in result["prior_diagnostics"]:
+                lines.append(f"- {hint['kind']} {hint['name']}: {hint['reason']}")
         optional_features = availability.get("optional_features") or []
         if optional_features:
             lines.append("Optional features:")

--- a/ts_agents/contracts.py
+++ b/ts_agents/contracts.py
@@ -20,6 +20,27 @@ class ArtifactRef:
 
 
 @dataclass
+class AnalysisLedgerEntry:
+    kind: str
+    key: str
+    value: Any
+    confidence: Optional[float] = None
+    evidence: List[str] = field(default_factory=list)
+    ruled_out: List[str] = field(default_factory=list)
+    notes: Optional[str] = None
+
+
+@dataclass
+class ForecastRecommendation:
+    choice: str
+    rationale: List[str] = field(default_factory=list)
+    preconditions_met: List[str] = field(default_factory=list)
+    preconditions_missing: List[str] = field(default_factory=list)
+    confidence: Optional[float] = None
+    alternatives: List[str] = field(default_factory=list)
+
+
+@dataclass
 class ToolPayload:
     """Structured payload returned by machine-oriented tool wrappers."""
 

--- a/ts_agents/core/recommendations.py
+++ b/ts_agents/core/recommendations.py
@@ -118,13 +118,11 @@ def _as_mapping(value: Any) -> dict[str, Any]:
     return {}
 
 
-
 def _normalize_methods(methods: Iterable[str] | None) -> tuple[str, ...]:
     if methods is None:
         return _DEFAULT_AVAILABLE_METHODS
-    normalized = tuple(str(method) for method in methods if str(method))
+    normalized = tuple(s for method in methods if (s := str(method)))
     return normalized or _DEFAULT_AVAILABLE_METHODS
-
 
 
 def _lag_one_autocorrelation(acf: Sequence[float]) -> float:
@@ -136,13 +134,12 @@ def _lag_one_autocorrelation(acf: Sequence[float]) -> float:
     return value
 
 
-
 def _first_available(preferred: Sequence[str], available: Sequence[str]) -> str:
     for name in preferred:
         if name in available:
             return name
+    # _normalize_methods guarantees a non-empty sequence for this fallback path.
     return available[0]
-
 
 
 def _present(preferred: Sequence[str], available: Sequence[str], *, exclude: set[str]) -> list[str]:
@@ -156,7 +153,6 @@ def _present(preferred: Sequence[str], available: Sequence[str], *, exclude: set
             continue
         result.append(name)
     return result
-
 
 
 def _recommendation_confidence(

--- a/ts_agents/core/recommendations.py
+++ b/ts_agents/core/recommendations.py
@@ -1,0 +1,176 @@
+from __future__ import annotations
+
+from typing import Any, Iterable, Sequence
+
+import numpy as np
+
+from ts_agents.contracts import ForecastRecommendation
+
+_DEFAULT_AVAILABLE_METHODS = ("seasonal_naive", "theta", "ets", "arima")
+
+
+def recommend_forecasting_method(
+    *,
+    stats: Any,
+    periodicity: Any,
+    acf: Sequence[float],
+    available_methods: Iterable[str] | None = None,
+) -> ForecastRecommendation:
+    stats_dict = _as_mapping(stats)
+    periodicity_dict = _as_mapping(periodicity)
+    methods = _normalize_methods(available_methods)
+
+    length = int(stats_dict.get("length") or 0)
+    std = float(stats_dict.get("std") or 0.0)
+    dominant_period = float(periodicity_dict.get("dominant_period") or 0.0)
+    periodicity_confidence = float(periodicity_dict.get("confidence") or 0.0)
+    lag_one = _lag_one_autocorrelation(acf)
+    has_detected_seasonality = dominant_period > 1.0 and periodicity_confidence >= 0.2
+    seasonal_history_ok = has_detected_seasonality and length >= max(int(round(dominant_period * 2)), 24)
+    arima_history_ok = length >= 32
+    non_constant_series = std > 0.0
+
+    rationale: list[str] = []
+    preconditions_met: list[str] = []
+    preconditions_missing: list[str] = []
+    alternatives: list[str] = []
+
+    if non_constant_series:
+        preconditions_met.append("series_has_variation")
+    else:
+        preconditions_missing.append("series_has_variation")
+
+    if has_detected_seasonality:
+        preconditions_met.append("seasonality_detected")
+        rationale.append(
+            f"Detected a dominant period near {dominant_period:.1f} with confidence {periodicity_confidence:.2f}."
+        )
+    else:
+        preconditions_missing.append("seasonality_detected")
+
+    if seasonal_history_ok:
+        preconditions_met.append("seasonal_history_sufficient")
+    elif has_detected_seasonality:
+        preconditions_missing.append("seasonal_history_sufficient")
+        rationale.append("Seasonality is present but the history is short for more stable seasonal models.")
+
+    if arima_history_ok:
+        preconditions_met.append("history_sufficient_for_arima")
+    else:
+        preconditions_missing.append("history_sufficient_for_arima")
+
+    if abs(lag_one) >= 0.5:
+        preconditions_met.append("strong_short_lag_dependence")
+        rationale.append(f"Lag-1 autocorrelation is {lag_one:.2f}, indicating meaningful short-range dependence.")
+    else:
+        preconditions_missing.append("strong_short_lag_dependence")
+
+    choice = "seasonal_naive"
+    if has_detected_seasonality and seasonal_history_ok:
+        choice = _first_available(("seasonal_naive", "ets", "theta", "arima"), methods)
+        alternatives = _present(("ets", "theta", "arima"), methods, exclude={choice})
+        rationale.append("Start with a seasonal baseline before expanding to heavier seasonal models.")
+    elif abs(lag_one) >= 0.5:
+        choice = _first_available(("theta", "arima", "seasonal_naive", "ets"), methods)
+        alternatives = _present(("arima", "seasonal_naive", "ets"), methods, exclude={choice})
+        rationale.append("A low-cost autoregressive-style baseline is a good next step after diagnostics.")
+    else:
+        choice = _first_available(("theta", "seasonal_naive", "ets", "arima"), methods)
+        alternatives = _present(("seasonal_naive", "ets", "arima"), methods, exclude={choice})
+        rationale.append("Diagnostics are lightweight, so prefer a robust baseline before complex model search.")
+
+    if choice == "arima" and not arima_history_ok:
+        rationale.append("ARIMA remains available but history length is marginal, so treat the recommendation as low-confidence.")
+    if choice == "seasonal_naive" and has_detected_seasonality and not seasonal_history_ok:
+        rationale.append("Seasonal naive is still the safest baseline when seasonality is detected but evidence is limited.")
+
+    confidence = _recommendation_confidence(
+        periodicity_confidence=periodicity_confidence,
+        has_detected_seasonality=has_detected_seasonality,
+        seasonal_history_ok=seasonal_history_ok,
+        lag_one=lag_one,
+        non_constant_series=non_constant_series,
+    )
+
+    return ForecastRecommendation(
+        choice=choice,
+        rationale=rationale,
+        preconditions_met=preconditions_met,
+        preconditions_missing=preconditions_missing,
+        confidence=confidence,
+        alternatives=alternatives,
+    )
+
+
+def _as_mapping(value: Any) -> dict[str, Any]:
+    if value is None:
+        return {}
+    if isinstance(value, dict):
+        return value
+    to_dict = getattr(value, "to_dict", None)
+    if callable(to_dict):
+        mapped = to_dict()
+        if isinstance(mapped, dict):
+            return mapped
+    raw = getattr(value, "__dict__", None)
+    if isinstance(raw, dict):
+        return {k: v for k, v in raw.items() if not k.startswith("_")}
+    return {}
+
+
+
+def _normalize_methods(methods: Iterable[str] | None) -> tuple[str, ...]:
+    if methods is None:
+        return _DEFAULT_AVAILABLE_METHODS
+    normalized = tuple(str(method) for method in methods if str(method))
+    return normalized or _DEFAULT_AVAILABLE_METHODS
+
+
+
+def _lag_one_autocorrelation(acf: Sequence[float]) -> float:
+    if len(acf) <= 1:
+        return 0.0
+    value = float(acf[1])
+    if not np.isfinite(value):
+        return 0.0
+    return value
+
+
+
+def _first_available(preferred: Sequence[str], available: Sequence[str]) -> str:
+    for name in preferred:
+        if name in available:
+            return name
+    return available[0]
+
+
+
+def _present(preferred: Sequence[str], available: Sequence[str], *, exclude: set[str]) -> list[str]:
+    result: list[str] = []
+    for name in preferred:
+        if name in exclude or name not in available or name in result:
+            continue
+        result.append(name)
+    for name in available:
+        if name in exclude or name in result:
+            continue
+        result.append(name)
+    return result
+
+
+
+def _recommendation_confidence(
+    *,
+    periodicity_confidence: float,
+    has_detected_seasonality: bool,
+    seasonal_history_ok: bool,
+    lag_one: float,
+    non_constant_series: bool,
+) -> float:
+    score = 0.35 if non_constant_series else 0.1
+    if has_detected_seasonality:
+        score += min(max(periodicity_confidence, 0.0), 0.4)
+    if seasonal_history_ok:
+        score += 0.15
+    score += min(abs(lag_one), 1.0) * 0.1
+    return round(min(score, 0.95), 4)

--- a/ts_agents/resources/demo/README.md
+++ b/ts_agents/resources/demo/README.md
@@ -76,6 +76,7 @@ Outputs (under `outputs/demo_wisdm/`):
 - `window_scores.png`
 - `eval.json`
 - `confusion_matrix.png`
+- `report.md`
 
 ---
 
@@ -97,8 +98,11 @@ uv run ts-agents demo forecasting --full-data --horizon 12 --methods arima,ets,t
 Outputs (under `outputs/demo/` by default):
 
 - `forecast_comparison.json`
-- `forecast_comparison.png`
+- `forecast.json`
+- `forecast.csv`
+- `report.md`
 - `forecasting_report.md`
+- `forecast_comparison.png` (when plotting is available)
 
 ---
 

--- a/ts_agents/resources/skills/README.md
+++ b/ts_agents/resources/skills/README.md
@@ -10,6 +10,7 @@ skills/
   SKILLS.md                           # Aggregate skills summary (generated)
   activity-recognition/SKILL.md       # End-to-end windowing/classification workflow
   forecasting/SKILL.md                # Forecasting methods
+  forecasting/SKILL-pro.md            # Professional M4 benchmark workflow
   diagnostics/SKILL.md                # Quick EDA diagnostics
   decomposition/SKILL.md              # Decomposition methods
   classification/SKILL.md             # Time series classification

--- a/ts_agents/tools/registry.py
+++ b/ts_agents/tools/registry.py
@@ -8,7 +8,7 @@ This module provides:
 """
 
 from dataclasses import dataclass, field
-from typing import Callable, List, Optional, Dict, Any, Sequence
+from typing import Callable, List, Optional, Dict, Any
 from enum import Enum
 import inspect
 from importlib.util import find_spec
@@ -86,6 +86,13 @@ class ToolParameter:
 
 
 @dataclass
+class ToolPreconditionHint:
+    kind: str
+    name: str
+    reason: str
+
+
+@dataclass
 class ToolMetadata:
     """Metadata for a registered tool.
 
@@ -117,6 +124,14 @@ class ToolMetadata:
         Disk limit in MB (for sandbox)
     input_validation_fn : Callable, optional
         Custom validation function for parameters
+    install_hint : Optional[str], optional
+        Hint for installing missing dependencies
+    optional_dependency_note : Optional[str], optional
+        Note for optional dependencies
+    artifact_kinds : List[str], optional
+        Artifact kinds produced by the tool
+    prior_diagnostics : List[ToolPreconditionHint], optional
+        Precondition hints for the tool
     """
     name: str
     description: str
@@ -135,6 +150,7 @@ class ToolMetadata:
     install_hint: Optional[str] = None
     optional_dependency_note: Optional[str] = None
     artifact_kinds: List[str] = field(default_factory=list)
+    prior_diagnostics: List[ToolPreconditionHint] = field(default_factory=list)
 
     def get_signature(self) -> str:
         """Get function signature as string."""
@@ -597,6 +613,7 @@ def _register_default_tools() -> None:
         install_hint: Optional[str] = None,
         optional_dependency_note: Optional[str] = None,
         artifact_kinds: Optional[List[str]] = None,
+        prior_diagnostics: Optional[List[ToolPreconditionHint]] = None,
     ) -> None:
         ToolRegistry.register(ToolMetadata(
             name=name,
@@ -612,6 +629,7 @@ def _register_default_tools() -> None:
             install_hint=install_hint,
             optional_dependency_note=optional_dependency_note,
             artifact_kinds=list(artifact_kinds or []),
+            prior_diagnostics=list(prior_diagnostics or []),
         ))
 
     def _register_with_data(
@@ -628,6 +646,7 @@ def _register_default_tools() -> None:
         install_hint: Optional[str] = None,
         optional_dependency_note: Optional[str] = None,
         artifact_kinds: Optional[List[str]] = None,
+        prior_diagnostics: Optional[List[ToolPreconditionHint]] = None,
     ) -> None:
         resolved_artifact_kinds = artifact_kinds
         if resolved_artifact_kinds is None and dependencies and "matplotlib" in dependencies:
@@ -646,7 +665,11 @@ def _register_default_tools() -> None:
             install_hint=install_hint,
             optional_dependency_note=optional_dependency_note,
             artifact_kinds=resolved_artifact_kinds,
+            prior_diagnostics=prior_diagnostics,
         )
+
+    def _hint(kind: str, name: str, reason: str) -> ToolPreconditionHint:
+        return ToolPreconditionHint(kind=kind, name=name, reason=reason)
 
     # ---------------------------------------------------------------------
     # Data Loading Tool
@@ -793,6 +816,18 @@ def _register_default_tools() -> None:
         ],
         examples=["Forecast a series for the next 20 steps"],
         returns="ForecastResult with predictions",
+        prior_diagnostics=[
+            _hint(
+                "workflow",
+                "inspect-series",
+                "Inspect period, lag structure, and baseline recommendations before choosing ARIMA.",
+            ),
+            _hint(
+                "tool",
+                "detect_periodicity",
+                "Estimate season_length before fitting seasonal statistical models.",
+            ),
+        ],
     )
     _register_with_data(
         base_name="forecast_arima",
@@ -809,6 +844,18 @@ def _register_default_tools() -> None:
         ],
         examples=["Forecast bx001_real for next 20 steps"],
         returns="ForecastResult with structured forecast data",
+        prior_diagnostics=[
+            _hint(
+                "workflow",
+                "inspect-series",
+                "Inspect period, lag structure, and baseline recommendations before choosing ARIMA.",
+            ),
+            _hint(
+                "tool",
+                "detect_periodicity_with_data",
+                "Estimate season_length before fitting seasonal statistical models.",
+            ),
+        ],
     )
 
     _register_tool(
@@ -859,6 +906,13 @@ def _register_default_tools() -> None:
         ],
         examples=["Forecast using Theta method"],
         returns="ForecastResult with predictions",
+        prior_diagnostics=[
+            _hint(
+                "workflow",
+                "inspect-series",
+                "Use inspect-series first so Theta is chosen as an informed baseline rather than a blind default.",
+            ),
+        ],
     )
     _register_with_data(
         base_name="forecast_theta",
@@ -875,6 +929,13 @@ def _register_default_tools() -> None:
         ],
         examples=["Forecast using Theta method"],
         returns="ForecastResult with structured forecast data",
+        prior_diagnostics=[
+            _hint(
+                "workflow",
+                "inspect-series",
+                "Use inspect-series first so Theta is chosen as an informed baseline rather than a blind default.",
+            ),
+        ],
     )
 
     _register_tool(
@@ -970,6 +1031,18 @@ def _register_default_tools() -> None:
         ],
         examples=["Compare ARIMA vs ETS accuracy"],
         returns="Comparison results with metrics",
+        prior_diagnostics=[
+            _hint(
+                "workflow",
+                "inspect-series",
+                "Run inspect-series first to estimate seasonality and narrow the method set before comparison.",
+            ),
+            _hint(
+                "tool",
+                "forecast_seasonal_naive",
+                "Check a cheap seasonal baseline before comparing heavier forecasting backends.",
+            ),
+        ],
     )
     _register_with_data(
         base_name="compare_forecasts",
@@ -988,6 +1061,18 @@ def _register_default_tools() -> None:
         ],
         examples=["Compare ARIMA vs ETS accuracy"],
         returns="Comparison results with metrics",
+        prior_diagnostics=[
+            _hint(
+                "workflow",
+                "inspect-series",
+                "Run inspect-series first to estimate seasonality and narrow the method set before comparison.",
+            ),
+            _hint(
+                "tool",
+                "forecast_seasonal_naive_with_data",
+                "Check a cheap seasonal baseline before comparing heavier forecasting backends.",
+            ),
+        ],
     )
 
     # ---------------------------------------------------------------------
@@ -1501,6 +1586,13 @@ def _register_default_tools() -> None:
         ],
         examples=["Evaluate minirocket on windows of size 64"],
         returns="WindowedClassificationEvaluation with metric + embedded ClassificationResult",
+        prior_diagnostics=[
+            _hint(
+                "tool",
+                "select_window_size",
+                "Pick a stable window size before running the final classifier evaluation.",
+            ),
+        ],
     )
 
     _register_tool(
@@ -1544,6 +1636,13 @@ def _register_default_tools() -> None:
         ],
         examples=["Evaluate classifier directly from labeled CSV"],
         returns="WindowedClassificationEvaluation",
+        prior_diagnostics=[
+            _hint(
+                "tool",
+                "select_window_size_from_csv",
+                "Pick a stable window size before running the final classifier evaluation.",
+            ),
+        ],
     )
 
     # ---------------------------------------------------------------------

--- a/ts_agents/workflows/__init__.py
+++ b/ts_agents/workflows/__init__.py
@@ -475,6 +475,7 @@ _WORKFLOWS = {
         ],
         artifacts=[
             WorkflowArtifact("summary.json", "json", "Inspection summary JSON."),
+            WorkflowArtifact("ledger.json", "json", "Structured findings ledger for the inspection workflow."),
             WorkflowArtifact("report.md", "markdown", "Inspection workflow markdown report."),
             WorkflowArtifact(
                 "autocorrelation.png",
@@ -512,7 +513,7 @@ _WORKFLOWS = {
             "ts-agents workflow run inspect-series --run-id Re200Rm200 --variable bx001_real",
         ],
         capabilities={
-            "writes_artifacts": ["summary.json", "report.md", "autocorrelation.png"],
+            "writes_artifacts": ["summary.json", "ledger.json", "report.md", "autocorrelation.png"],
         },
         availability_fn=_inspect_workflow_availability,
     ),

--- a/ts_agents/workflows/common.py
+++ b/ts_agents/workflows/common.py
@@ -10,7 +10,7 @@ from typing import Any
 import uuid
 
 from ts_agents.cli.output import render_output, to_jsonable, write_output
-from ts_agents.contracts import ArtifactRef, CLI_SCHEMA_VERSION, ToolPayload
+from ts_agents.contracts import AnalysisLedgerEntry, ArtifactRef, CLI_SCHEMA_VERSION, ToolPayload
 
 WORKFLOW_MANIFEST_FILENAME = "run_manifest.json"
 
@@ -80,6 +80,27 @@ def write_json_artifact(
         path=output_path,
         mime_type="application/json",
         description=description,
+        created_by=created_by,
+    )
+
+
+def write_ledger_artifact(
+    *,
+    entries: list[AnalysisLedgerEntry],
+    path: str | Path,
+    created_by: str,
+) -> ArtifactRef:
+    payload = {
+        "schema_version": CLI_SCHEMA_VERSION,
+        "kind": "analysis_ledger",
+        "workflow": created_by,
+        "created_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+        "entries": entries,
+    }
+    return write_json_artifact(
+        data=payload,
+        path=path,
+        description="Structured analysis ledger for workflow findings and recommendations.",
         created_by=created_by,
     )
 

--- a/ts_agents/workflows/inspect.py
+++ b/ts_agents/workflows/inspect.py
@@ -46,6 +46,7 @@ def run_inspect_series_workflow(
         stats=stats,
         periodicity=periodicity,
         acf=acf,
+        available_methods=_available_forecasting_methods(),
     )
 
     recommended_next_steps = _recommend_next_steps(
@@ -161,6 +162,15 @@ def run_inspect_series_workflow(
         resumed=resumed,
         output_dir_mode=output_dir_mode,
     )
+
+
+def _available_forecasting_methods() -> list[str]:
+    from ts_agents.workflows import get_workflow
+
+    availability = get_workflow("forecast-series").availability()
+    methods = availability.get("available_methods") or ["seasonal_naive"]
+    normalized = [str(method) for method in methods if str(method)]
+    return normalized or ["seasonal_naive"]
 
 
 def _recommend_next_steps(

--- a/ts_agents/workflows/inspect.py
+++ b/ts_agents/workflows/inspect.py
@@ -8,12 +8,13 @@ import numpy as np
 
 from ts_agents.cli.input_parsing import SeriesInput
 from ts_agents.cli.output import to_jsonable
-from ts_agents.contracts import ToolPayload
+from ts_agents.contracts import AnalysisLedgerEntry, ForecastRecommendation, ToolPayload
 
 from .common import (
     attach_workflow_run_metadata,
     ensure_output_dir,
     write_json_artifact,
+    write_ledger_artifact,
     write_plot_artifact,
     write_text_artifact,
 )
@@ -30,6 +31,7 @@ def run_inspect_series_workflow(
     output_dir_mode: str = "explicit",
 ) -> ToolPayload:
     """Run a lightweight diagnostics workflow on an arbitrary series."""
+    from ts_agents.core.recommendations import recommend_forecasting_method
     from ts_agents.core.spectral import detect_periodicity
     from ts_agents.core.statistics import compute_autocorrelation, describe_series
 
@@ -40,6 +42,11 @@ def run_inspect_series_workflow(
 
     resolved_max_lag = max_lag if max_lag is not None else min(64, max(8, len(series_input.series) // 4))
     acf = compute_autocorrelation(series_input.series, max_lag=resolved_max_lag)
+    forecast_recommendation = recommend_forecasting_method(
+        stats=stats,
+        periodicity=periodicity,
+        acf=acf,
+    )
 
     recommended_next_steps = _recommend_next_steps(
         periodicity=periodicity,
@@ -47,6 +54,13 @@ def run_inspect_series_workflow(
         length=len(series_input.series),
     )
     effective_max_lag = max(len(acf) - 1, 0)
+    lag_one = float(acf[1]) if len(acf) > 1 else None
+    ledger_entries = _build_analysis_ledger(
+        stats=to_jsonable(stats),
+        periodicity=to_jsonable(periodicity),
+        lag_one=lag_one,
+        forecast_recommendation=forecast_recommendation,
+    )
     summary_data = {
         "workflow": workflow_name,
         "source": series_input.provenance.get("series_ref", {}),
@@ -56,8 +70,9 @@ def run_inspect_series_workflow(
         "autocorrelation": {
             "max_lag": int(effective_max_lag),
             "requested_max_lag": int(resolved_max_lag),
-            "lag_1": float(acf[1]) if len(acf) > 1 else None,
+            "lag_1": lag_one,
         },
+        "forecast_recommendation": to_jsonable(forecast_recommendation),
         "recommended_next_steps": recommended_next_steps,
         "output_dir": str(output_path),
     }
@@ -68,7 +83,12 @@ def run_inspect_series_workflow(
             path=output_path / "summary.json",
             description="Inspection summary JSON.",
             created_by=workflow_name,
-        )
+        ),
+        write_ledger_artifact(
+            entries=ledger_entries,
+            path=output_path / "ledger.json",
+            created_by=workflow_name,
+        ),
     ]
     warnings: List[str] = []
 
@@ -96,8 +116,9 @@ def run_inspect_series_workflow(
 
     report = _build_report(
         series_input=series_input,
-        stats=to_jsonable(stats),
-        periodicity=to_jsonable(periodicity),
+        stats=summary_data["stats"],
+        periodicity=summary_data["periodicity"],
+        forecast_recommendation=summary_data["forecast_recommendation"],
         recommended_next_steps=recommended_next_steps,
     )
     artifacts.append(
@@ -111,10 +132,12 @@ def run_inspect_series_workflow(
 
     dominant_period = summary_data["periodicity"].get("dominant_period")
     lag_one = summary_data["autocorrelation"].get("lag_1")
+    recommended_method = summary_data["forecast_recommendation"].get("choice")
     summary = (
         f"Inspect-series workflow completed for {series_input.label}. "
         f"Dominant period: {_format_number(dominant_period)}; "
-        f"lag-1 autocorrelation: {_format_number(lag_one)}."
+        f"lag-1 autocorrelation: {_format_number(lag_one)}; "
+        f"forecast start: {recommended_method or 'n/a'}."
     )
     payload = ToolPayload(
         kind="workflow",
@@ -160,15 +183,64 @@ def _recommend_next_steps(
     return steps
 
 
+def _build_analysis_ledger(
+    *,
+    stats: dict[str, Any],
+    periodicity: dict[str, Any],
+    lag_one: float | None,
+    forecast_recommendation: ForecastRecommendation,
+) -> List[AnalysisLedgerEntry]:
+    entries: List[AnalysisLedgerEntry] = [
+        AnalysisLedgerEntry(
+            kind="finding",
+            key="series_length",
+            value=int(stats.get("length") or 0),
+            confidence=1.0,
+            evidence=["summary.json#stats"],
+        ),
+        AnalysisLedgerEntry(
+            kind="finding",
+            key="dominant_period",
+            value=periodicity.get("dominant_period"),
+            confidence=_optional_float(periodicity.get("confidence")),
+            evidence=["summary.json#periodicity"],
+            notes="Dominant FFT-derived period estimate from inspect-series.",
+        ),
+        AnalysisLedgerEntry(
+            kind="finding",
+            key="lag_1_autocorrelation",
+            value=lag_one,
+            confidence=min(abs(lag_one), 1.0) if lag_one is not None else None,
+            evidence=["summary.json#autocorrelation"],
+        ),
+        AnalysisLedgerEntry(
+            kind="recommendation",
+            key="forecasting_method",
+            value=forecast_recommendation.choice,
+            confidence=forecast_recommendation.confidence,
+            evidence=[
+                "summary.json#stats",
+                "summary.json#periodicity",
+                "summary.json#autocorrelation",
+            ],
+            notes="; ".join(forecast_recommendation.rationale),
+        ),
+    ]
+    return entries
+
+
 def _build_report(
     *,
     series_input: SeriesInput,
     stats: dict[str, Any],
     periodicity: dict[str, Any],
+    forecast_recommendation: dict[str, Any],
     recommended_next_steps: List[str],
 ) -> str:
     top_periods = periodicity.get("top_periods") or []
     next_steps_lines = [f"- {step}" for step in recommended_next_steps]
+    rationale = forecast_recommendation.get("rationale") or []
+    rationale_lines = [f"- {item}" for item in rationale]
     return "\n".join(
         [
             "### Report on Inspect-Series Workflow",
@@ -181,6 +253,11 @@ def _build_report(
             f"- **Dominant Period**: {_format_number(periodicity.get('dominant_period'))}",
             f"- **Periodicity Confidence**: {_format_number(periodicity.get('confidence'))}",
             f"- **Top Periods**: {', '.join(_format_number(value) for value in top_periods) if top_periods else 'n/a'}",
+            f"- **Forecast Start Method**: {forecast_recommendation.get('choice', 'n/a')}",
+            f"- **Recommendation Confidence**: {_format_number(forecast_recommendation.get('confidence'))}",
+            "",
+            "#### Forecast Recommendation Rationale",
+            *(rationale_lines or ["- n/a"]),
             "",
             "#### Recommended Next Steps",
             *next_steps_lines,
@@ -194,3 +271,9 @@ def _format_number(value: Any) -> str:
     if isinstance(value, (int, float)):
         return f"{value:.4f}"
     return str(value)
+
+
+def _optional_float(value: Any) -> float | None:
+    if value is None:
+        return None
+    return float(value)


### PR DESCRIPTION
Closes #79
Closes #80
Closes #81

## Summary
- fix docs and packaged-resource drift around source-checkout install profiles, demo output paths, and packaged skill listings
- add `AnalysisLedgerEntry` and `ForecastRecommendation` contracts plus a pure recommendation helper for exploration-first forecasting guidance
- update `inspect-series` to emit `forecast_recommendation` in `summary.json`, add `ledger.json` as a first-class artifact, and document the new outputs
- extend tool metadata with `prior_diagnostics` hints and surface them in `tool show --json` and tool discovery/search output
- add focused CLI and recommendation tests, including regression coverage for the new `prior_diagnostics` serialization and a text-formatting check for `capabilities`

## Why It Changed
Recent review follow-ups identified three open slices that were already being implemented together on stacked local branches:
- docs and install guidance still drifted from current CLI behavior
- the exploration-first workflow story relied too much on prose rather than a typed findings/recommendation contract
- tool metadata did not expose the diagnostic steps an agent should usually complete before selecting heavier methods

## User / Developer Impact
- source-checkout users now get explicit guidance about when plain `uv sync` is base-only versus when `--extra recommended` or `--extra ui` is required
- `inspect-series` now produces machine-readable recommendation and ledger artifacts that downstream automation can consume directly
- tool discovery now exposes prior-diagnostic hints so agents can choose methods with better context instead of treating every tool as equally ready

## Root Cause
The repo had already moved toward workflow-first, exploration-first automation, but a few key contracts were still missing in code and several docs/resources still reflected older install and demo assumptions.

## Validation
- `uv run python -m pytest -q tests/cli/test_entrypoints.py tests/test_hosted_app.py tests/test_package_metadata.py tests/core/test_recommendations.py tests/cli/test_params.py tests/cli/test_sandbox.py tests/cli/test_workflows.py`
- result: `98 passed`
- `uv run ts-agents tool show forecast_arima --json`
- `uv run ts-agents tool search arima --json`
- `uv run ts-agents workflow show inspect-series --json`
- `uv run ts-agents workflow run inspect-series --input-json '{"series":[1,2,3,4,5,6,7,8,9,10,11,12]}' --skip-plots --output-dir /tmp/ts-agents-inspect-smoke --overwrite --json`

## Manifest / Profile Impacts
- `inspect-series` now writes an additive `ledger.json` artifact and includes `forecast_recommendation` in `summary.json`
- tool discovery/detail JSON now exposes additive `prior_diagnostics` metadata
- no dependency manifest changes

## Risks
- the recommendation helper is intentionally heuristic and should be treated as an initial baseline-selection contract rather than a full planner
- closing three related review-remediation slices in one PR means the diff is broader than the branch name suggests, so review should be done by slice (`#79`, `#80`, `#81`) rather than by filename order