### PR TITLE
[codex] De-domain default prompts and benchmark reasoning checks

### DIFF
--- a/tests/agents/test_benchmarks.py
+++ b/tests/agents/test_benchmarks.py
@@ -51,6 +51,8 @@ class TestBenchmarkScenarios:
         assert "query" in data
         assert "difficulty" in data
         assert "expected" in data
+        assert "reasoning_must_contain" in data["expected"]
+        assert "reasoning_should_contain" in data["expected"]
 
     def test_get_scenarios_by_difficulty(self):
         """Test filtering scenarios by difficulty."""
@@ -128,6 +130,8 @@ class TestExpectedOutcome:
         assert expected.required_tools == []
         assert expected.optional_tools == []
         assert expected.must_contain == []
+        assert expected.reasoning_must_contain == []
+        assert expected.reasoning_should_contain == []
         assert expected.expects_number is False
         assert expected.min_tool_calls == 0
         assert expected.max_tool_calls == 10
@@ -139,12 +143,14 @@ class TestExpectedOutcome:
         expected = ExpectedOutcome(
             required_tools=["detect_peaks"],
             must_contain=["peak"],
+            reasoning_should_contain=["inspect"],
             expects_number=True,
             min_tool_calls=1,
         )
 
         assert expected.required_tools == ["detect_peaks"]
         assert expected.must_contain == ["peak"]
+        assert expected.reasoning_should_contain == ["inspect"]
         assert expected.expects_number is True
         assert expected.min_tool_calls == 1
 
@@ -256,6 +262,48 @@ class TestMetrics:
 
         assert result_with_number.format_score > result_without_number.format_score
 
+    def test_evaluate_response_reasoning_quality(self):
+        """Test evaluation of reasoning quality expectations."""
+        from ts_agents.agents.benchmarks.metrics import evaluate_response
+        from ts_agents.agents.benchmarks.scenarios import ExpectedOutcome
+
+        expected = ExpectedOutcome(
+            reasoning_must_contain=["inspect", "availability"],
+            reasoning_should_contain=["confidence"],
+        )
+
+        result = evaluate_response(
+            response=(
+                "Inspect seasonality first, then compare heavier methods "
+                "only after checking availability and confidence."
+            ),
+            tool_calls=[],
+            expected=expected,
+        )
+
+        assert result.reasoning_score > 0.9
+        assert "inspect" in result.reasoning_matches
+        assert "availability" in result.reasoning_matches
+
+    def test_evaluate_response_missing_required_reasoning_fails(self):
+        """Test missing required reasoning cues fail evaluation."""
+        from ts_agents.agents.benchmarks.metrics import evaluate_response
+        from ts_agents.agents.benchmarks.scenarios import ExpectedOutcome
+
+        expected = ExpectedOutcome(
+            reasoning_must_contain=["inspect", "availability"],
+        )
+
+        result = evaluate_response(
+            response="Run the heaviest model immediately.",
+            tool_calls=[],
+            expected=expected,
+        )
+
+        assert result.passed is False
+        assert "inspect" in result.reasoning_misses
+        assert "availability" in result.reasoning_misses
+
     def test_evaluation_result_dataclass(self):
         """Test EvaluationResult dataclass."""
         from ts_agents.agents.benchmarks.metrics import EvaluationResult
@@ -263,6 +311,7 @@ class TestMetrics:
         result = EvaluationResult(
             tool_score=0.8,
             content_score=0.9,
+            reasoning_score=0.7,
             format_score=1.0,
             overall_score=0.87,
             tools_used=["detect_peaks"],
@@ -270,6 +319,7 @@ class TestMetrics:
         )
 
         assert result.tool_score == 0.8
+        assert result.reasoning_score == 0.7
         assert result.passed is True
         assert len(result.failure_reasons) == 0
 
@@ -283,11 +333,13 @@ class TestMetrics:
         evaluations = [
             EvaluationResult(
                 tool_score=0.8, content_score=0.9,
-                format_score=1.0, overall_score=0.87, passed=True,
+                reasoning_score=0.7, format_score=1.0,
+                overall_score=0.87, passed=True,
             ),
             EvaluationResult(
                 tool_score=0.5, content_score=0.5,
-                format_score=0.5, overall_score=0.5, passed=False,
+                reasoning_score=0.4, format_score=0.5,
+                overall_score=0.5, passed=False,
                 failure_reasons=["Missing content"],
             ),
         ]
@@ -299,6 +351,7 @@ class TestMetrics:
         assert summary["failed"] == 1
         assert summary["pass_rate"] == 0.5
         assert "avg_overall_score" in summary
+        assert "avg_reasoning_score" in summary
 
     def test_summarize_evaluations_empty(self):
         """Test summarizing empty evaluation list."""
@@ -347,7 +400,8 @@ class TestBenchmarkResult:
             duration_ms=1500.0,
             evaluation=EvaluationResult(
                 tool_score=1.0, content_score=1.0,
-                format_score=1.0, overall_score=1.0, passed=True,
+                reasoning_score=1.0, format_score=1.0,
+                overall_score=1.0, passed=True,
             ),
         )
 
@@ -356,6 +410,7 @@ class TestBenchmarkResult:
         assert data["scenario_name"] == "simple_peak_count"
         assert data["success"] is True
         assert data["evaluation"]["passed"] is True
+        assert data["evaluation"]["reasoning_score"] == 1.0
 
 
 class TestAgentConfig:
@@ -431,7 +486,8 @@ class TestAgentBenchmarkInfrastructure:
                 duration_ms=100.0,
                 evaluation=EvaluationResult(
                     tool_score=1.0, content_score=1.0,
-                    format_score=1.0, overall_score=1.0, passed=True,
+                    reasoning_score=1.0, format_score=1.0,
+                    overall_score=1.0, passed=True,
                 ),
             ),
             BenchmarkResult(
@@ -445,7 +501,8 @@ class TestAgentBenchmarkInfrastructure:
                 duration_ms=200.0,
                 evaluation=EvaluationResult(
                     tool_score=0.5, content_score=0.5,
-                    format_score=0.5, overall_score=0.5, passed=False,
+                    reasoning_score=0.5, format_score=0.5,
+                    overall_score=0.5, passed=False,
                 ),
             ),
         ]

--- a/tests/agents/test_benchmarks.py
+++ b/tests/agents/test_benchmarks.py
@@ -53,6 +53,15 @@ class TestBenchmarkScenarios:
         assert "expected" in data
         assert "reasoning_must_contain" in data["expected"]
         assert "reasoning_should_contain" in data["expected"]
+        assert "reasoning_must_not_contain" in data["expected"]
+
+    def test_forecast_comparison_documents_reasoning_guardrail(self):
+        """Test forecast comparison scenario documents a soft reasoning guardrail."""
+        from ts_agents.agents.benchmarks.scenarios import BENCHMARK_SCENARIOS
+
+        scenario = BENCHMARK_SCENARIOS["forecast_comparison"]
+
+        assert scenario.expected.reasoning_must_not_contain == ["guarantee"]
 
     def test_get_scenarios_by_difficulty(self):
         """Test filtering scenarios by difficulty."""
@@ -132,6 +141,7 @@ class TestExpectedOutcome:
         assert expected.must_contain == []
         assert expected.reasoning_must_contain == []
         assert expected.reasoning_should_contain == []
+        assert expected.reasoning_must_not_contain == []
         assert expected.expects_number is False
         assert expected.min_tool_calls == 0
         assert expected.max_tool_calls == 10
@@ -144,6 +154,7 @@ class TestExpectedOutcome:
             required_tools=["detect_peaks"],
             must_contain=["peak"],
             reasoning_should_contain=["inspect"],
+            reasoning_must_not_contain=["guarantee"],
             expects_number=True,
             min_tool_calls=1,
         )
@@ -151,6 +162,7 @@ class TestExpectedOutcome:
         assert expected.required_tools == ["detect_peaks"]
         assert expected.must_contain == ["peak"]
         assert expected.reasoning_should_contain == ["inspect"]
+        assert expected.reasoning_must_not_contain == ["guarantee"]
         assert expected.expects_number is True
         assert expected.min_tool_calls == 1
 
@@ -303,6 +315,25 @@ class TestMetrics:
         assert result.passed is False
         assert "inspect" in result.reasoning_misses
         assert "availability" in result.reasoning_misses
+
+    def test_evaluate_response_reasoning_must_not_contain_is_soft_penalty(self):
+        """Test reasoning must-not terms lower score without creating hard misses."""
+        from ts_agents.agents.benchmarks.metrics import evaluate_response
+        from ts_agents.agents.benchmarks.scenarios import ExpectedOutcome
+
+        expected = ExpectedOutcome(
+            reasoning_must_not_contain=["guarantee"],
+        )
+
+        result = evaluate_response(
+            response="I can guarantee this forecast will be best.",
+            tool_calls=[],
+            expected=expected,
+        )
+
+        assert result.reasoning_score == pytest.approx(0.8)
+        assert result.reasoning_misses == []
+        assert result.passed is True
 
     def test_evaluation_result_dataclass(self):
         """Test EvaluationResult dataclass."""

--- a/tests/agents/test_deep_agent.py
+++ b/tests/agents/test_deep_agent.py
@@ -353,6 +353,10 @@ class TestSystemPrompts:
 
         # Should mention cost awareness
         assert "cost" in prompt.lower()
+        assert "inspect" in prompt.lower()
+        assert "availability" in prompt.lower()
+        assert "Re200Rm200" not in prompt
+        assert "bx001_real" not in prompt
 
     def test_decomposition_system_prompt(self):
         """Test decomposition agent system prompt."""

--- a/tests/agents/test_simple_agent.py
+++ b/tests/agents/test_simple_agent.py
@@ -14,6 +14,8 @@ class TestPrompts:
 
         assert "time series" in prompt.lower()
         assert "analysis" in prompt.lower()
+        assert "Re200Rm200" not in prompt
+        assert "bx001_real" not in prompt
 
     def test_get_system_prompt_with_tools(self):
         """Test system prompt includes tool names."""
@@ -43,6 +45,19 @@ class TestPrompts:
 
         # Should still have basic content but not data-specific info
         assert "time series" in prompt.lower()
+        assert "Re200Rm200" not in prompt
+        assert "bx001_real" not in prompt
+
+    def test_get_system_prompt_with_explicit_data_context_prompt(self):
+        """Test system prompt can accept explicit caller-provided data context."""
+        from ts_agents.agents.simple.prompts import get_system_prompt
+
+        prompt = get_system_prompt(
+            data_context_prompt="## Available Data\n- Dataset: battery_cells.csv"
+        )
+
+        assert "Available Data" in prompt
+        assert "battery_cells.csv" in prompt
 
     def test_get_system_prompt_custom_instructions(self):
         """Test system prompt with custom instructions."""

--- a/tests/agents/test_simple_agent.py
+++ b/tests/agents/test_simple_agent.py
@@ -184,9 +184,35 @@ class TestAgentCreationConfiguration:
         assert "full" in bundles
         assert "all" in bundles
 
+    def test_create_simple_agent_signature_preserves_positional_compatibility(self):
+        """Test create_simple_agent keeps new data context as keyword-only."""
+        import inspect
+        from ts_agents.agents.simple.agent import create_simple_agent
+
+        params = inspect.signature(create_simple_agent).parameters
+
+        assert list(params)[5] == "enable_logging"
+        assert params["data_context_prompt"].kind is inspect.Parameter.KEYWORD_ONLY
+
 
 class TestSimpleAgentChatDataStructures:
     """Tests for SimpleAgentChat supporting data structures."""
+
+    def test_simple_agent_chat_forwards_data_context_prompt(self, monkeypatch):
+        """Test SimpleAgentChat forwards explicit data context to agent creation."""
+        import ts_agents.agents.simple.agent as agent_module
+
+        captured = {}
+
+        def fake_create_simple_agent(**kwargs):
+            captured.update(kwargs)
+            return object()
+
+        monkeypatch.setattr(agent_module, "create_simple_agent", fake_create_simple_agent)
+
+        agent_module.SimpleAgentChat(data_context_prompt="## Available Data\n- Dataset: batteries.csv")
+
+        assert captured["data_context_prompt"] == "## Available Data\n- Dataset: batteries.csv"
 
     def test_get_tool_stats_empty(self):
         """Test tool stats with no calls."""

--- a/ts_agents/agents/benchmarks/metrics.py
+++ b/ts_agents/agents/benchmarks/metrics.py
@@ -314,11 +314,7 @@ def _determine_pass(
             return False
 
     if result.reasoning_misses:
-        must_reasoning_misses = [
-            miss for miss in result.reasoning_misses if miss in expected.reasoning_must_contain
-        ]
-        if must_reasoning_misses:
-            return False
+        return False
 
     # Pass if overall score is above threshold
     return result.overall_score >= 0.5

--- a/ts_agents/agents/benchmarks/metrics.py
+++ b/ts_agents/agents/benchmarks/metrics.py
@@ -18,6 +18,7 @@ class EvaluationResult:
     # Scores (0.0 to 1.0)
     tool_score: float = 0.0
     content_score: float = 0.0
+    reasoning_score: float = 0.0
     format_score: float = 0.0
     overall_score: float = 0.0
 
@@ -29,6 +30,8 @@ class EvaluationResult:
 
     content_matches: List[str] = field(default_factory=list)
     content_misses: List[str] = field(default_factory=list)
+    reasoning_matches: List[str] = field(default_factory=list)
+    reasoning_misses: List[str] = field(default_factory=list)
 
     # Pass/fail
     passed: bool = False
@@ -75,14 +78,21 @@ def evaluate_response(
     result.content_matches = content_details["matches"]
     result.content_misses = content_details["misses"]
 
+    # Evaluate reasoning quality
+    reasoning_score, reasoning_details = _evaluate_reasoning(response, expected)
+    result.reasoning_score = reasoning_score
+    result.reasoning_matches = reasoning_details["matches"]
+    result.reasoning_misses = reasoning_details["misses"]
+
     # Evaluate format
     format_score = _evaluate_format(response, expected)
     result.format_score = format_score
 
     # Calculate overall score (weighted average)
     result.overall_score = (
-        0.4 * tool_score +
-        0.4 * content_score +
+        0.3 * tool_score +
+        0.3 * content_score +
+        0.2 * reasoning_score +
         0.2 * format_score
     )
 
@@ -101,6 +111,10 @@ def evaluate_response(
     if result.content_misses:
         result.failure_reasons.append(
             f"Missing required content: {result.content_misses}"
+        )
+    if result.reasoning_misses:
+        result.failure_reasons.append(
+            f"Missing required reasoning cues: {result.reasoning_misses}"
         )
 
     return result
@@ -200,6 +214,48 @@ def _evaluate_content(
     return max(0.0, score), details
 
 
+def _evaluate_reasoning(
+    response: str,
+    expected: ExpectedOutcome,
+) -> tuple:
+    """Evaluate reasoning quality cues against expectations."""
+    details = {"matches": [], "misses": []}
+    response_lower = response.lower()
+
+    must_contain_score = 0.0
+    if expected.reasoning_must_contain:
+        matches = []
+        for term in expected.reasoning_must_contain:
+            if term.lower() in response_lower:
+                matches.append(term)
+        details["matches"].extend(matches)
+        details["misses"] = [
+            term for term in expected.reasoning_must_contain if term.lower() not in response_lower
+        ]
+        must_contain_score = len(matches) / len(expected.reasoning_must_contain)
+    else:
+        must_contain_score = 1.0
+
+    should_contain_score = 0.0
+    if expected.reasoning_should_contain:
+        matches = []
+        for term in expected.reasoning_should_contain:
+            if term.lower() in response_lower:
+                matches.append(term)
+        details["matches"].extend(matches)
+        should_contain_score = len(matches) / len(expected.reasoning_should_contain)
+    else:
+        should_contain_score = 1.0
+
+    must_not_penalty = 0.0
+    for term in expected.reasoning_must_not_contain:
+        if term.lower() in response_lower:
+            must_not_penalty += 0.2
+
+    score = (0.7 * must_contain_score + 0.3 * should_contain_score) - must_not_penalty
+    return max(0.0, score), details
+
+
 def _evaluate_format(
     response: str,
     expected: ExpectedOutcome,
@@ -257,6 +313,13 @@ def _determine_pass(
         if must_misses:
             return False
 
+    if result.reasoning_misses:
+        must_reasoning_misses = [
+            miss for miss in result.reasoning_misses if miss in expected.reasoning_must_contain
+        ]
+        if must_reasoning_misses:
+            return False
+
     # Pass if overall score is above threshold
     return result.overall_score >= 0.5
 
@@ -294,6 +357,7 @@ def compute_agent_metrics(
     # Aggregate scores
     tool_scores = [e.tool_score for e in evaluations]
     content_scores = [e.content_score for e in evaluations]
+    reasoning_scores = [e.reasoning_score for e in evaluations]
     overall_scores = [e.overall_score for e in evaluations]
     pass_count = sum(1 for e in evaluations if e.passed)
 
@@ -319,10 +383,13 @@ def compute_agent_metrics(
 
         "tool_score_mean": sum(tool_scores) / len(tool_scores),
         "content_score_mean": sum(content_scores) / len(content_scores),
+        "reasoning_score_mean": sum(reasoning_scores) / len(reasoning_scores),
         "overall_score_mean": sum(overall_scores) / len(overall_scores),
 
         "tool_score_min": min(tool_scores),
         "tool_score_max": max(tool_scores),
+        "reasoning_score_min": min(reasoning_scores),
+        "reasoning_score_max": max(reasoning_scores),
         "overall_score_min": min(overall_scores),
         "overall_score_max": max(overall_scores),
 
@@ -369,6 +436,7 @@ def summarize_evaluations(
 
         "avg_tool_score": sum(e.tool_score for e in evaluations) / len(evaluations),
         "avg_content_score": sum(e.content_score for e in evaluations) / len(evaluations),
+        "avg_reasoning_score": sum(e.reasoning_score for e in evaluations) / len(evaluations),
         "avg_format_score": sum(e.format_score for e in evaluations) / len(evaluations),
         "avg_overall_score": sum(e.overall_score for e in evaluations) / len(evaluations),
 

--- a/ts_agents/agents/benchmarks/runner.py
+++ b/ts_agents/agents/benchmarks/runner.py
@@ -66,6 +66,7 @@ class BenchmarkResult:
             "evaluation": {
                 "tool_score": self.evaluation.tool_score,
                 "content_score": self.evaluation.content_score,
+                "reasoning_score": self.evaluation.reasoning_score,
                 "format_score": self.evaluation.format_score,
                 "overall_score": self.evaluation.overall_score,
                 "passed": self.evaluation.passed,

--- a/ts_agents/agents/benchmarks/scenarios.py
+++ b/ts_agents/agents/benchmarks/scenarios.py
@@ -36,6 +36,9 @@ class ExpectedOutcome:
     must_contain: List[str] = field(default_factory=list)
     should_contain: List[str] = field(default_factory=list)
     must_not_contain: List[str] = field(default_factory=list)
+    reasoning_must_contain: List[str] = field(default_factory=list)
+    reasoning_should_contain: List[str] = field(default_factory=list)
+    reasoning_must_not_contain: List[str] = field(default_factory=list)
 
     # Format expectations
     expects_number: bool = False
@@ -77,6 +80,8 @@ class BenchmarkScenario:
                 "required_tools": self.expected.required_tools,
                 "optional_tools": self.expected.optional_tools,
                 "must_contain": self.expected.must_contain,
+                "reasoning_must_contain": self.expected.reasoning_must_contain,
+                "reasoning_should_contain": self.expected.reasoning_should_contain,
                 "expects_number": self.expected.expects_number,
             },
         }
@@ -250,6 +255,7 @@ register_scenario(BenchmarkScenario(
         required_tools=["compare_forecasts"],
         optional_tools=["forecast_arima", "forecast_ets", "forecast_theta", "forecast_ensemble"],
         must_contain=["arima", "ets"],
+        reasoning_should_contain=["compare", "confidence", "availability"],
         expects_recommendation=True,
         min_tool_calls=1,
         max_tool_calls=5,
@@ -286,6 +292,7 @@ register_scenario(BenchmarkScenario(
     expected=ExpectedOutcome(
         required_tools=["stl_decompose", "mstl_decompose", "holt_winters_decompose"],
         must_contain=["stl", "trend"],
+        reasoning_should_contain=["because", "seasonal", "inspect"],
         expects_recommendation=True,
         min_tool_calls=1,
         max_tool_calls=5,

--- a/ts_agents/agents/benchmarks/scenarios.py
+++ b/ts_agents/agents/benchmarks/scenarios.py
@@ -38,6 +38,7 @@ class ExpectedOutcome:
     must_not_contain: List[str] = field(default_factory=list)
     reasoning_must_contain: List[str] = field(default_factory=list)
     reasoning_should_contain: List[str] = field(default_factory=list)
+    # Soft penalty only; this discourages overclaiming without forcing a hard fail.
     reasoning_must_not_contain: List[str] = field(default_factory=list)
 
     # Format expectations
@@ -82,6 +83,7 @@ class BenchmarkScenario:
                 "must_contain": self.expected.must_contain,
                 "reasoning_must_contain": self.expected.reasoning_must_contain,
                 "reasoning_should_contain": self.expected.reasoning_should_contain,
+                "reasoning_must_not_contain": self.expected.reasoning_must_not_contain,
                 "expects_number": self.expected.expects_number,
             },
         }
@@ -256,6 +258,7 @@ register_scenario(BenchmarkScenario(
         optional_tools=["forecast_arima", "forecast_ets", "forecast_theta", "forecast_ensemble"],
         must_contain=["arima", "ets"],
         reasoning_should_contain=["compare", "confidence", "availability"],
+        reasoning_must_not_contain=["guarantee"],
         expects_recommendation=True,
         min_tool_calls=1,
         max_tool_calls=5,

--- a/ts_agents/agents/deep/orchestrator.py
+++ b/ts_agents/agents/deep/orchestrator.py
@@ -56,7 +56,8 @@ ORCHESTRATOR_SYSTEM_PROMPT = """You are a time series analysis orchestrator.
 
 Your role is to understand user requests and delegate to specialized sub-agents
 when appropriate. You have access to high-level tools for quick analysis and
-can delegate complex tasks to specialists.
+can delegate complex tasks to specialists. Do not assume a fixed domain or a
+preloaded dataset unless the user or runtime context explicitly provides one.
 
 ## Your Sub-Agents
 
@@ -86,34 +87,34 @@ You can delegate to these specialists using the task tool:
 
 1. **Understand the request**: What does the user want to achieve?
 
-2. **Quick analysis**: Use your tools for simple requests:
+2. **Explore before specializing**:
+   - Start with lightweight discovery and diagnostics when the right method is not obvious
+   - Prefer inspection and comparison before recommending an expensive specialized method
+   - Call out weak evidence, availability constraints, and install-profile caveats
+
+3. **Quick analysis**: Use your tools for simple requests:
    - Basic statistics: describe_series_with_data
    - Quick decomposition: stl_decompose_with_data
    - Ensemble forecast: forecast_ensemble_with_data
    - Pattern overview: analyze_matrix_profile_with_data
 
-3. **Complex tasks**: Delegate to specialists when:
+4. **Complex tasks**: Delegate to specialists when:
    - User needs method comparison/selection
    - Domain expertise is required
    - Multi-step analysis needed
 
-4. **Synthesize results**: After delegation:
+5. **Synthesize results**: After delegation:
    - Summarize key findings
    - Provide actionable insights
    - Suggest follow-up analysis
 
-## Available Data
-
-CFD/MHD simulation data at different Reynolds numbers:
-- Runs: Re200Rm200, Re175Rm175, Re150Rm150, Re125Rm125, Re105Rm105, Re102_5Rm102_5
-- Variables: bx001_real, by001_real, vx001_imag, vy001_imag, ex001_imag, ey001_imag
-
 ## Important Notes
 
 - **Cost awareness**: Some tools are expensive (marked VERY_HIGH cost)
-- **Results persistence**: Check /results/ for cached analyses
+- **Results persistence**: Check the results cache for previous analyses when helpful
 - **Confidence intervals**: Always report uncertainty when forecasting
 - **Visualization**: Include plots when helpful
+- **Domain routing**: Use the turbulence-agent only when the request is clearly CFD/MHD-specific
 
 ## Response Format
 

--- a/ts_agents/agents/simple/agent.py
+++ b/ts_agents/agents/simple/agent.py
@@ -68,10 +68,11 @@ def create_simple_agent(
     custom_tools: Optional[List[str]] = None,
     temperature: float = 0,
     include_data_info: bool = False,
-    data_context_prompt: Optional[str] = None,
     enable_logging: bool = True,
     capture_results: bool = False,
     log_callback: Optional[Callable[[Dict[str, Any]], None]] = None,
+    *,
+    data_context_prompt: Optional[str] = None,
 ) -> Any:
     """Create a simple LangChain agent for time series analysis.
 
@@ -92,14 +93,14 @@ def create_simple_agent(
         LLM temperature (0 = deterministic)
     include_data_info : bool
         Include the bundled CFD/MHD data context in the system prompt
-    data_context_prompt : str, optional
-        Explicit domain or dataset context to append to the system prompt
     enable_logging : bool
         Enable logging of tool calls and decisions
     capture_results : bool
         Capture JSON-serializable tool results in log entries (may be large)
     log_callback : Callable, optional
         Custom callback for logging events
+    data_context_prompt : str, optional
+        Explicit domain or dataset context to append to the system prompt
 
     Returns
     -------
@@ -292,6 +293,10 @@ class SimpleAgentChat:
         Custom tool list
     enable_logging : bool
         Enable detailed logging
+    capture_results : bool
+        Capture JSON-serializable tool outputs in the session log
+    data_context_prompt : str, optional
+        Explicit domain or dataset context to pass through to create_simple_agent
 
     Examples
     --------
@@ -311,6 +316,8 @@ class SimpleAgentChat:
         custom_tools: Optional[List[str]] = None,
         enable_logging: bool = True,
         capture_results: bool = False,
+        *,
+        data_context_prompt: Optional[str] = None,
     ):
         self._tool_calls: List[ToolCallRecord] = []
 
@@ -333,6 +340,7 @@ class SimpleAgentChat:
             enable_logging=enable_logging,
             capture_results=capture_results,
             log_callback=log_callback,
+            data_context_prompt=data_context_prompt,
         )
 
         self.messages: List[Any] = []

--- a/ts_agents/agents/simple/agent.py
+++ b/ts_agents/agents/simple/agent.py
@@ -67,7 +67,8 @@ def create_simple_agent(
     tool_bundle: str = "standard",
     custom_tools: Optional[List[str]] = None,
     temperature: float = 0,
-    include_data_info: bool = True,
+    include_data_info: bool = False,
+    data_context_prompt: Optional[str] = None,
     enable_logging: bool = True,
     capture_results: bool = False,
     log_callback: Optional[Callable[[Dict[str, Any]], None]] = None,
@@ -90,7 +91,9 @@ def create_simple_agent(
     temperature : float
         LLM temperature (0 = deterministic)
     include_data_info : bool
-        Include CFD data info in system prompt
+        Include the bundled CFD/MHD data context in the system prompt
+    data_context_prompt : str, optional
+        Explicit domain or dataset context to append to the system prompt
     enable_logging : bool
         Enable logging of tool calls and decisions
     capture_results : bool
@@ -148,6 +151,7 @@ def create_simple_agent(
     system_prompt = get_system_prompt(
         tool_names=tool_names,
         include_data_info=include_data_info,
+        data_context_prompt=data_context_prompt,
     )
     bundle_prompt = get_bundle_prompt(bundle_name)
     full_prompt = system_prompt + "\n" + bundle_prompt

--- a/ts_agents/agents/simple/prompts.py
+++ b/ts_agents/agents/simple/prompts.py
@@ -10,7 +10,8 @@ from ...config import AVAILABLE_RUNS, REAL_VARIABLES, IMAG_VARIABLES
 
 def get_system_prompt(
     tool_names: Optional[List[str]] = None,
-    include_data_info: bool = True,
+    include_data_info: bool = False,
+    data_context_prompt: Optional[str] = None,
     custom_instructions: Optional[str] = None,
 ) -> str:
     """Generate system prompt for the simple agent.
@@ -20,7 +21,9 @@ def get_system_prompt(
     tool_names : List[str], optional
         List of available tool names (for context in prompt)
     include_data_info : bool
-        Whether to include CFD data information
+        Whether to include the bundled CFD/MHD data context
+    data_context_prompt : str, optional
+        Explicit domain or dataset context to append to the prompt
     custom_instructions : str, optional
         Additional instructions to append
 
@@ -31,8 +34,10 @@ def get_system_prompt(
     """
     parts = [BASE_PROMPT]
 
-    if include_data_info:
-        parts.append(DATA_INFO_PROMPT)
+    if data_context_prompt:
+        parts.append(data_context_prompt)
+    elif include_data_info:
+        parts.append(MHD_DATA_CONTEXT_PROMPT)
 
     parts.append(CAPABILITIES_PROMPT)
 
@@ -52,14 +57,14 @@ def get_system_prompt(
 # Prompt Components
 # -----------------------------------------------------------------------------
 
-BASE_PROMPT = """You are a time series analysis agent specializing in scientific data analysis.
+BASE_PROMPT = """You are a time series analysis agent.
 
 Your role is to help users analyze time series data using a variety of statistical
 and machine learning techniques. You have access to tools for decomposition,
 forecasting, pattern detection, classification, spectral analysis, and more."""
 
 
-DATA_INFO_PROMPT = f"""
+MHD_DATA_CONTEXT_PROMPT = f"""
 ## Available Data
 
 The data comes from MHD (Magnetohydrodynamic) simulations with different Reynolds
@@ -131,21 +136,29 @@ GUIDELINES_PROMPT = """
 3. **Start Simple**: Begin with basic tools (describe_series, detect_peaks) before
    using more complex ones.
 
-4. **Explain Results**: Provide clear interpretations of analysis results in
+4. **Use Exploration-First Reasoning**: When method choice is unclear, inspect
+   basic statistics, periodicity, and other lightweight diagnostics before
+   recommending an expensive or specialized approach.
+
+5. **Explain Results**: Provide clear interpretations of analysis results in
    scientific terms.
 
-5. **Handle Errors Gracefully**: If a tool fails, explain what went wrong and
+6. **Handle Errors Gracefully**: If a tool fails, explain what went wrong and
    suggest alternatives.
 
-6. **Ask for Clarification**: If the user doesn't specify a run ID or variable,
-   ask them or suggest Re200Rm200 as a good starting point (most turbulent case).
+7. **Ask for Clarification**: If the user doesn't identify the input series,
+   file, run, or variable, ask for it. Only suggest domain-specific bundled
+   data when the prompt explicitly includes that context.
 
-7. **Consider Computational Cost**: Some tools (like HC2 classification or
+8. **Consider Computational Cost**: Some tools (like HC2 classification or
    ensemble forecasting) are computationally expensive. Mention this before
    running them.
 
-8. **Compare When Useful**: When the user wants to understand which method is
-   best, use comparison tools to evaluate multiple approaches."""
+9. **Compare When Useful**: When the user wants to understand which method is
+   best, use comparison tools to evaluate multiple approaches.
+
+10. **Call Out Caveats**: If confidence is weak or a method depends on optional
+    extras, say so explicitly instead of pretending the result is unconditional."""
 
 
 # -----------------------------------------------------------------------------

--- a/ts_agents/cli/__init__.py
+++ b/ts_agents/cli/__init__.py
@@ -1,5 +1,15 @@
 """Command-line interface for ts-agents."""
 
-from .main import main
+from __future__ import annotations
+
+from typing import Any
+
+
+def main(*args: Any, **kwargs: Any) -> Any:
+    """Lazily load the CLI entrypoint to avoid package import cycles."""
+    from .main import main as _main
+
+    return _main(*args, **kwargs)
+
 
 __all__ = ["main"]


### PR DESCRIPTION
## Summary
- make the default simple-agent and deep-agent prompts domain-neutral instead of assuming bundled CFD/MHD context
- keep bundled CFD/MHD guidance behind explicit opt-in data-context injection and turbulence-specific routing
- extend benchmark expectations, scoring, and summaries with reasoning-quality checks
- add focused tests for prompt neutrality, explicit data context, and reasoning evaluation behavior
- fix a `ts_agents.cli` import cycle surfaced by the focused agent test slice

## Why
Issue #83 tracks two gaps in the agent stack:
1. the default prompts were biased toward the bundled CFD/MHD dataset even when the user had not provided that context
2. the benchmark harness only checked tool/content/format behavior and did not score reasoning quality

The prompt assumptions made the generic agent surfaces less reusable, and the benchmark contracts could not enforce exploration-first reasoning cues.

## Impact
- default agent entrypoints now start from a domain-neutral baseline
- callers can still inject explicit domain/data context when they want the bundled CFD/MHD framing
- benchmark results now expose reasoning-quality scores alongside the existing tool/content/format metrics
- the CLI package import path no longer trips a circular import when tool modules import `ts_agents.cli.output`

## Validation
- `uv run python -m pytest -q tests/agents/test_simple_agent.py tests/agents/test_deep_agent.py tests/agents/test_benchmarks.py`
- `uv run ts-agents --help`

## Risks
- benchmark score weighting changed to include reasoning quality, so downstream consumers that interpret overall benchmark scores may see shifts
- callers that implicitly relied on the old bundled CFD/MHD prompt defaults now need to opt in explicitly

Closes #83