### PR TITLE
[codex] Improve activity-recognition input prep and diagnostics

### DIFF
--- a/skills/activity-recognition/SKILL.md
+++ b/skills/activity-recognition/SKILL.md
@@ -63,6 +63,20 @@ This:
 3. writes plots into `outputs/activity-recognition/`
 4. writes a short report to `outputs/activity-recognition/report.md`
 
+If signals and labels live in separate files, the workflow can prepare the labeled stream directly:
+
+```bash
+uv run ts-agents workflow run activity-recognition \
+  --input signals.csv \
+  --time-col ts \
+  --value-cols x,y,z \
+  --labels-input segments.csv \
+  --labels-start-col start \
+  --labels-end-col end \
+  --label-col activity \
+  --output-dir outputs/activity-recognition
+```
+
 ## Customize the workflow
 
 ```bash
@@ -73,6 +87,9 @@ uv run ts-agents workflow run activity-recognition \
   --window-sizes 32,64,128 \
   --classifier minirocket \
   --metric balanced_accuracy \
+  --labeling majority \
+  --stride 16 \
+  --n-splits 5 \
   --output-dir outputs/activity-recognition
 ```
 

--- a/tests/cli/test_input_parsing.py
+++ b/tests/cli/test_input_parsing.py
@@ -56,3 +56,61 @@ def test_labeled_stream_input_rejects_missing_labels(missing_label):
             value_cols=["x", "y"],
             label_col="label",
         )
+
+
+def test_load_labeled_stream_input_merges_row_aligned_labels_from_separate_file(tmp_path):
+    signal_path = tmp_path / "signals.csv"
+    signal_path.write_text(
+        "x,y,z\n"
+        "0,0,0\n"
+        "1,1,1\n"
+        "2,2,2\n"
+    )
+    labels_path = tmp_path / "labels.csv"
+    labels_path.write_text(
+        "label\n"
+        "idle\n"
+        "walk\n"
+        "walk\n"
+    )
+
+    stream_input = load_labeled_stream_input(
+        input_path=str(signal_path),
+        value_cols=["x", "y", "z"],
+        label_col="label",
+        labels_input_path=str(labels_path),
+    )
+
+    assert stream_input.labels.tolist() == ["idle", "walk", "walk"]
+    assert stream_input.provenance["stream_ref"]["label_source"]["path"] == str(labels_path)
+    assert stream_input.provenance["stream_ref"]["preparation"]["mode"] == "row_aligned_labels"
+
+
+def test_load_labeled_stream_input_expands_segment_labels_by_time_column(tmp_path):
+    signal_path = tmp_path / "signals.csv"
+    signal_path.write_text(
+        "ts,x,y,z\n"
+        "0,0,0,0\n"
+        "1,1,1,1\n"
+        "2,2,2,2\n"
+        "3,3,3,3\n"
+    )
+    labels_path = tmp_path / "segments.csv"
+    labels_path.write_text(
+        "start,end,label\n"
+        "0,2,idle\n"
+        "2,4,walk\n"
+    )
+
+    stream_input = load_labeled_stream_input(
+        input_path=str(signal_path),
+        time_col="ts",
+        value_cols=["x", "y", "z"],
+        label_col="label",
+        labels_input_path=str(labels_path),
+        label_start_col="start",
+        label_end_col="end",
+    )
+
+    assert stream_input.labels.tolist() == ["idle", "idle", "walk", "walk"]
+    assert stream_input.provenance["stream_ref"]["preparation"]["mode"] == "segment_time_labels"

--- a/tests/cli/test_input_parsing.py
+++ b/tests/cli/test_input_parsing.py
@@ -86,6 +86,58 @@ def test_load_labeled_stream_input_merges_row_aligned_labels_from_separate_file(
     assert stream_input.provenance["stream_ref"]["preparation"]["mode"] == "row_aligned_labels"
 
 
+def test_load_labeled_stream_input_prefers_row_alignment_over_incidental_start_end_columns(tmp_path):
+    signal_path = tmp_path / "signals.csv"
+    signal_path.write_text(
+        "x,y,z\n"
+        "0,0,0\n"
+        "1,1,1\n"
+    )
+    labels_path = tmp_path / "labels.csv"
+    labels_path.write_text(
+        "label,start,end\n"
+        "idle,100,200\n"
+        "walk,300,400\n"
+    )
+
+    stream_input = load_labeled_stream_input(
+        input_path=str(signal_path),
+        value_cols=["x", "y", "z"],
+        label_col="label",
+        labels_input_path=str(labels_path),
+    )
+
+    assert stream_input.labels.tolist() == ["idle", "walk"]
+    assert stream_input.provenance["stream_ref"]["preparation"]["mode"] == "row_aligned_labels"
+
+
+def test_load_labeled_stream_input_prefers_explicit_time_alignment_over_row_alignment(tmp_path):
+    signal_path = tmp_path / "signals.csv"
+    signal_path.write_text(
+        "ts,x,y,z\n"
+        "1,0,0,0\n"
+        "2,1,1,1\n"
+    )
+    labels_path = tmp_path / "labels.csv"
+    labels_path.write_text(
+        "observed_at,label\n"
+        "2,walk\n"
+        "1,idle\n"
+    )
+
+    stream_input = load_labeled_stream_input(
+        input_path=str(signal_path),
+        time_col="ts",
+        value_cols=["x", "y", "z"],
+        label_col="label",
+        labels_input_path=str(labels_path),
+        labels_time_col="observed_at",
+    )
+
+    assert stream_input.labels.tolist() == ["idle", "walk"]
+    assert stream_input.provenance["stream_ref"]["preparation"]["mode"] == "time_joined_labels"
+
+
 def test_load_labeled_stream_input_expands_segment_labels_by_time_column(tmp_path):
     signal_path = tmp_path / "signals.csv"
     signal_path.write_text(
@@ -114,3 +166,32 @@ def test_load_labeled_stream_input_expands_segment_labels_by_time_column(tmp_pat
 
     assert stream_input.labels.tolist() == ["idle", "idle", "walk", "walk"]
     assert stream_input.provenance["stream_ref"]["preparation"]["mode"] == "segment_time_labels"
+
+
+def test_load_labeled_stream_input_segment_labels_support_non_identifier_column_names(tmp_path):
+    signal_path = tmp_path / "signals.csv"
+    signal_path.write_text(
+        "x,y,z\n"
+        "0,0,0\n"
+        "1,1,1\n"
+        "2,2,2\n"
+        "3,3,3\n"
+    )
+    labels_path = tmp_path / "segments.csv"
+    labels_path.write_text(
+        "segment start,segment-end,activity label\n"
+        "0,2,idle\n"
+        "2,4,walk\n"
+    )
+
+    stream_input = load_labeled_stream_input(
+        input_path=str(signal_path),
+        value_cols=["x", "y", "z"],
+        label_col="activity label",
+        labels_input_path=str(labels_path),
+        label_start_col="segment start",
+        label_end_col="segment-end",
+    )
+
+    assert stream_input.labels.tolist() == ["idle", "idle", "walk", "walk"]
+    assert stream_input.provenance["stream_ref"]["preparation"]["mode"] == "segment_index_labels"

--- a/tests/cli/test_params.py
+++ b/tests/cli/test_params.py
@@ -645,6 +645,42 @@ def test_workflow_parser_rejects_conflicting_primary_sources():
         )
 
 
+def test_activity_workflow_parser_accepts_separate_labels_and_windowing_controls():
+    parser = build_parser()
+    args = parser.parse_args(
+        [
+            "workflow",
+            "run",
+            "activity-recognition",
+            "--input",
+            "signals.csv",
+            "--labels-input",
+            "segments.csv",
+            "--labels-start-col",
+            "start",
+            "--labels-end-col",
+            "end",
+            "--label-col",
+            "activity",
+            "--value-cols",
+            "x,y,z",
+            "--labeling",
+            "majority",
+            "--stride",
+            "16",
+            "--n-splits",
+            "5",
+        ]
+    )
+
+    assert args.labels_input == "segments.csv"
+    assert args.labels_start_col == "start"
+    assert args.labels_end_col == "end"
+    assert args.labeling == "majority"
+    assert args.stride == 16
+    assert args.n_splits == 5
+
+
 def test_tool_run_json_includes_artifact_refs_for_payload_wrappers(
     monkeypatch,
     capsys,

--- a/tests/cli/test_workflows.py
+++ b/tests/cli/test_workflows.py
@@ -1820,6 +1820,90 @@ def test_workflow_run_activity_recognition_report_surfaces_retention_drops(
     assert "No obvious pathologies" not in report_text
 
 
+def test_workflow_run_activity_recognition_surfaces_classifier_backend_warnings(
+    monkeypatch,
+    capsys,
+    tmp_path,
+):
+    import ts_agents.core.windowing as windowing
+
+    class FakeSelection:
+        best_window_size = 64
+        metric = "balanced_accuracy"
+
+        def to_dict(self):
+            return {
+                "method": "window_size_selection",
+                "best_window_size": 64,
+                "metric": "balanced_accuracy",
+                "scores_by_window": {64: 0.8},
+                "n_windows_by_window": {64: 20},
+                "details": {"n_splits": 3, "window_diagnostics": {64: {"n_windows": 20, "retained_classes": ["idle", "walk"], "dropped_classes": [], "valid_split_count": 3}}},
+            }
+
+    class FakeEval:
+        metric = "balanced_accuracy"
+        score = 0.8
+
+        def to_dict(self):
+            return {
+                "method": "windowed_classification",
+                "window_size": 64,
+                "stride": 32,
+                "classifier": "minirocket",
+                "metric": "balanced_accuracy",
+                "score": 0.8,
+                "n_windows": 20,
+                "n_splits": 3,
+                "split_scores": [0.8],
+                "retained_classes": ["idle", "walk"],
+                "dropped_classes": [],
+                "class_counts": {"idle": 10, "walk": 10},
+                "classification": {
+                    "method": "rocket_fallback",
+                    "warnings": ["ROCKET backend fallback activated during fit/predict: RuntimeError: broken aeon"],
+                    "accuracy": 0.8,
+                    "f1_score": 0.8,
+                    "confusion_matrix": [[4, 1], [1, 4]],
+                    "predictions": ["idle", "walk"],
+                },
+            }
+
+    monkeypatch.setattr(windowing, "select_window_size", lambda *args, **kwargs: FakeSelection())
+    monkeypatch.setattr(windowing, "evaluate_windowed_classifier", lambda *args, **kwargs: FakeEval())
+
+    csv_path = tmp_path / "stream.csv"
+    csv_path.write_text(
+        "x,y,z,label\n"
+        "0,0,0,idle\n"
+        "1,1,1,idle\n"
+        "2,2,2,walk\n"
+        "3,3,3,walk\n"
+    )
+
+    code = run(
+        [
+            "workflow",
+            "run",
+            "activity-recognition",
+            "--input",
+            str(csv_path),
+            "--label-col",
+            "label",
+            "--value-cols",
+            "x,y,z",
+            "--skip-plots",
+            "--json",
+        ]
+    )
+
+    assert code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["degraded"] is True
+    assert "classifier_backend_warning" in payload["result"]["data"]["quality_flags"]
+    assert any("fallback activated" in warning for warning in payload["result"]["warnings"])
+
+
 def test_handle_workflow_command_uses_registry_runner(monkeypatch):
     import importlib
     import ts_agents.workflows as workflows

--- a/tests/cli/test_workflows.py
+++ b/tests/cli/test_workflows.py
@@ -1598,6 +1598,228 @@ def test_workflow_run_activity_recognition_continues_when_plot_generation_fails(
     assert not (output_dir / "confusion_matrix.png").exists()
 
 
+def test_workflow_run_activity_recognition_threads_new_windowing_controls(
+    monkeypatch,
+    capsys,
+    tmp_path,
+):
+    import ts_agents.core.windowing as windowing
+
+    observed = {}
+
+    class FakeSelection:
+        best_window_size = 64
+        metric = "balanced_accuracy"
+
+        def to_dict(self):
+            return {
+                "method": "window_size_selection",
+                "best_window_size": 64,
+                "metric": "balanced_accuracy",
+                "scores_by_window": {64: 0.78},
+                "n_windows_by_window": {64: 24},
+                "details": {
+                    "n_splits": 5,
+                    "window_diagnostics": {
+                        64: {
+                            "n_windows": 24,
+                            "retained_classes": ["idle", "walk"],
+                            "dropped_classes": [],
+                            "valid_split_count": 5,
+                        }
+                    },
+                },
+            }
+
+    class FakeEval:
+        metric = "balanced_accuracy"
+        score = 0.76
+
+        def to_dict(self):
+            return {
+                "method": "windowed_classification",
+                "window_size": 64,
+                "stride": 16,
+                "classifier": "minirocket",
+                "metric": "balanced_accuracy",
+                "score": 0.76,
+                "n_windows": 24,
+                "n_splits": 5,
+                "split_scores": [0.74, 0.78],
+                "retained_classes": ["idle", "walk"],
+                "dropped_classes": [],
+                "class_counts": {"idle": 12, "walk": 12},
+                "details": {"valid_split_count": 5},
+                "classification": {
+                    "method": "minirocket",
+                    "accuracy": 0.79,
+                    "f1_score": 0.75,
+                    "confusion_matrix": [[6, 2], [3, 5]],
+                    "predictions": ["idle", "walk"],
+                },
+            }
+
+    def fake_select_window_size(*args, **kwargs):
+        observed["selection_kwargs"] = kwargs
+        return FakeSelection()
+
+    def fake_evaluate_windowed_classifier(*args, **kwargs):
+        observed["evaluation_kwargs"] = kwargs
+        return FakeEval()
+
+    monkeypatch.setattr(windowing, "select_window_size", fake_select_window_size)
+    monkeypatch.setattr(windowing, "evaluate_windowed_classifier", fake_evaluate_windowed_classifier)
+
+    csv_path = tmp_path / "stream.csv"
+    csv_path.write_text(
+        "x,y,z,label\n"
+        "0,0,0,idle\n"
+        "1,1,1,idle\n"
+        "2,2,2,walk\n"
+        "3,3,3,walk\n"
+    )
+
+    code = run(
+        [
+            "workflow",
+            "run",
+            "activity-recognition",
+            "--input",
+            str(csv_path),
+            "--label-col",
+            "label",
+            "--value-cols",
+            "x,y,z",
+            "--labeling",
+            "majority",
+            "--stride",
+            "16",
+            "--n-splits",
+            "5",
+            "--skip-plots",
+            "--json",
+        ]
+    )
+
+    assert code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert observed["selection_kwargs"]["labeling"] == "majority"
+    assert observed["selection_kwargs"]["stride"] == 16
+    assert observed["selection_kwargs"]["n_splits"] == 5
+    assert observed["evaluation_kwargs"]["labeling"] == "majority"
+    assert observed["evaluation_kwargs"]["stride"] == 16
+    assert observed["evaluation_kwargs"]["n_splits"] == 5
+    assert payload["result"]["data"]["labeling"] == "majority"
+    assert payload["result"]["data"]["stride_requested"] == 16
+    assert payload["result"]["data"]["n_splits"] == 5
+
+
+def test_workflow_run_activity_recognition_report_surfaces_retention_drops(
+    monkeypatch,
+    capsys,
+    tmp_path,
+):
+    import ts_agents.core.windowing as windowing
+
+    class FakeSelection:
+        best_window_size = 96
+        metric = "balanced_accuracy"
+
+        def to_dict(self):
+            return {
+                "method": "window_size_selection",
+                "best_window_size": 96,
+                "metric": "balanced_accuracy",
+                "scores_by_window": {32: 0.72, 96: 0.91},
+                "n_windows_by_window": {32: 40, 96: 12},
+                "details": {
+                    "n_splits": 3,
+                    "window_diagnostics": {
+                        32: {
+                            "n_windows": 40,
+                            "retained_classes": ["idle", "walk", "stairs"],
+                            "dropped_classes": [],
+                            "valid_split_count": 3,
+                        },
+                        96: {
+                            "n_windows": 12,
+                            "retained_classes": ["idle", "walk"],
+                            "dropped_classes": ["stairs"],
+                            "valid_split_count": 1,
+                        },
+                    },
+                },
+            }
+
+    class FakeEval:
+        metric = "balanced_accuracy"
+        score = 0.91
+
+        def to_dict(self):
+            return {
+                "method": "windowed_classification",
+                "window_size": 96,
+                "stride": 48,
+                "classifier": "minirocket",
+                "metric": "balanced_accuracy",
+                "score": 0.91,
+                "n_windows": 12,
+                "n_splits": 1,
+                "split_scores": [0.91],
+                "retained_classes": ["idle", "walk"],
+                "dropped_classes": ["stairs"],
+                "class_counts": {"idle": 7, "walk": 5},
+                "details": {"valid_split_count": 1},
+                "classification": {
+                    "method": "minirocket",
+                    "accuracy": 0.93,
+                    "f1_score": 0.9,
+                    "confusion_matrix": [[4, 1], [0, 5]],
+                    "predictions": ["idle", "walk"],
+                },
+            }
+
+    monkeypatch.setattr(windowing, "select_window_size", lambda *args, **kwargs: FakeSelection())
+    monkeypatch.setattr(windowing, "evaluate_windowed_classifier", lambda *args, **kwargs: FakeEval())
+
+    csv_path = tmp_path / "stream.csv"
+    csv_path.write_text(
+        "x,y,z,label\n"
+        "0,0,0,idle\n"
+        "1,1,1,idle\n"
+        "2,2,2,walk\n"
+        "3,3,3,walk\n"
+    )
+    output_dir = tmp_path / "activity"
+
+    code = run(
+        [
+            "workflow",
+            "run",
+            "activity-recognition",
+            "--input",
+            str(csv_path),
+            "--label-col",
+            "label",
+            "--value-cols",
+            "x,y,z",
+            "--skip-plots",
+            "--output-dir",
+            str(output_dir),
+            "--json",
+        ]
+    )
+
+    assert code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["quality_status"] == "degraded"
+    report_text = (output_dir / "report.md").read_text()
+    assert "Window Sweep" in report_text
+    assert "Dropped Classes" in report_text
+    assert "`stairs`" in report_text
+    assert "No obvious pathologies" not in report_text
+
+
 def test_handle_workflow_command_uses_registry_runner(monkeypatch):
     import importlib
     import ts_agents.workflows as workflows

--- a/tests/core/test_classification.py
+++ b/tests/core/test_classification.py
@@ -100,6 +100,7 @@ class TestKNNClassification:
 
         assert result.method == "knn_euclidean_fallback"
         assert len(result.predictions) == 5
+        assert any("fallback activated" in warning for warning in result.warnings)
 
 
 class TestROCKETClassification:
@@ -143,6 +144,7 @@ class TestROCKETClassification:
 
         assert result.method == "rocket_fallback"
         assert len(result.predictions) == 5
+        assert any("fallback activated" in warning for warning in result.warnings)
 
 
 class TestEnsure3D:

--- a/tests/core/test_classification.py
+++ b/tests/core/test_classification.py
@@ -1,5 +1,8 @@
 """Tests for the classification module."""
 
+import sys
+import types
+
 import numpy as np
 import pytest
 
@@ -74,6 +77,30 @@ class TestKNNClassification:
         # Same series should have distance 0
         assert compute_dtw_distance(x, x) < 0.01
 
+    def test_knn_classify_falls_back_when_aeon_runtime_breaks(self, monkeypatch):
+        from ts_agents.core.classification import knn_classify
+
+        broken_module = types.ModuleType("aeon.classification.distance_based")
+
+        class BrokenKNNClassifier:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            def fit(self, X, y):
+                raise RuntimeError("aeon runtime is broken")
+
+        broken_module.KNeighborsTimeSeriesClassifier = BrokenKNNClassifier
+
+        monkeypatch.setitem(sys.modules, "aeon", types.ModuleType("aeon"))
+        monkeypatch.setitem(sys.modules, "aeon.classification", types.ModuleType("aeon.classification"))
+        monkeypatch.setitem(sys.modules, "aeon.classification.distance_based", broken_module)
+
+        X, y = create_synthetic_data(n_samples=20)
+        result = knn_classify(X[:15], y[:15], X[15:], y[15:], distance="dtw")
+
+        assert result.method == "knn_euclidean_fallback"
+        assert len(result.predictions) == 5
+
 
 class TestROCKETClassification:
     """Tests for ROCKET classification."""
@@ -90,6 +117,32 @@ class TestROCKETClassification:
 
         assert len(result.predictions) == 10
         assert result.accuracy is not None
+
+    def test_rocket_classify_falls_back_when_aeon_runtime_breaks(self, monkeypatch):
+        from ts_agents.core.classification import rocket_classify
+
+        broken_module = types.ModuleType("aeon.classification.convolution_based")
+
+        class BrokenRocketClassifier:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            def fit(self, X, y):
+                raise RuntimeError("aeon runtime is broken")
+
+        broken_module.RocketClassifier = BrokenRocketClassifier
+        broken_module.MiniRocketClassifier = BrokenRocketClassifier
+        broken_module.MultiRocketClassifier = BrokenRocketClassifier
+
+        monkeypatch.setitem(sys.modules, "aeon", types.ModuleType("aeon"))
+        monkeypatch.setitem(sys.modules, "aeon.classification", types.ModuleType("aeon.classification"))
+        monkeypatch.setitem(sys.modules, "aeon.classification.convolution_based", broken_module)
+
+        X, y = create_synthetic_data(n_samples=20)
+        result = rocket_classify(X[:15], y[:15], X[15:], y[15:], variant="rocket")
+
+        assert result.method == "rocket_fallback"
+        assert len(result.predictions) == 5
 
 
 class TestEnsure3D:

--- a/tests/core/test_windowing.py
+++ b/tests/core/test_windowing.py
@@ -1,5 +1,6 @@
 import numpy as np
 import warnings
+import json
 
 from ts_agents.core.base import ClassificationResult
 from ts_agents.core.windowing import select_window_size, evaluate_windowed_classifier
@@ -134,3 +135,65 @@ def test_balanced_accuracy_single_class_no_warning():
         score = window_selection._score_metric("balanced_accuracy", y_true, y_pred)
 
     assert score == 1.0
+
+
+def test_evaluate_windowed_classifier_supports_multiple_group_splits(monkeypatch):
+    series, labels = _make_series()
+
+    observed = {}
+
+    def fake_iter_valid_group_splits(X, y, groups, *, n_splits, **kwargs):
+        observed["n_splits"] = n_splits
+        return [
+            (np.array([0, 1, 2, 3]), np.array([4, 5])),
+            (np.array([2, 3, 4, 5]), np.array([0, 1])),
+        ]
+
+    def fake_knn(X_train, y_train, X_test, y_test, **kwargs):
+        return ClassificationResult(
+            method="knn_stub",
+            predictions=np.asarray(y_test),
+            accuracy=1.0,
+        )
+
+    monkeypatch.setattr(window_selection, "_iter_valid_group_splits", fake_iter_valid_group_splits)
+    monkeypatch.setattr(window_selection, "knn_classify", fake_knn)
+
+    result = window_selection.evaluate_windowed_classifier(
+        series,
+        labels,
+        window_size=8,
+        classifier="knn",
+        metric="accuracy",
+        balance="none",
+        n_splits=2,
+        test_size=0.34,
+    )
+
+    assert observed["n_splits"] == 2
+    assert result.n_splits == 2
+    assert result.split_scores == [1.0, 1.0]
+    assert result.classification["method"] == "knn_stub"
+
+
+def test_select_window_size_from_csv_accepts_json_records(tmp_path):
+    series, labels = _make_series()
+    records = [
+        {"value": float(value), "label": label}
+        for value, label in zip(series.tolist(), labels.tolist())
+    ]
+    json_path = tmp_path / "stream.json"
+    json_path.write_text(json.dumps(records))
+
+    result = window_selection.select_window_size_from_csv(
+        str(json_path),
+        value_columns="value",
+        label_column="label",
+        classifier="knn",
+        metric="accuracy",
+        balance="none",
+        n_splits=1,
+        test_size=0.34,
+    )
+
+    assert result.best_window_size in result.scores_by_window

--- a/ts_agents/cli/input_parsing.py
+++ b/ts_agents/cli/input_parsing.py
@@ -191,6 +191,11 @@ def load_labeled_stream_input(
     time_col: Optional[str] = None,
     value_cols: Optional[list[str]] = None,
     label_col: str = "label",
+    labels_input_path: Optional[str] = None,
+    labels_input_json: Optional[str] = None,
+    labels_time_col: Optional[str] = None,
+    label_start_col: Optional[str] = None,
+    label_end_col: Optional[str] = None,
 ) -> LabeledStreamInput:
     """Load a labeled multivariate stream for activity-recognition workflows."""
     source_count = sum(
@@ -203,12 +208,74 @@ def load_labeled_stream_input(
             "Provide exactly one activity-recognition input source: --input, --input-json, or --stdin."
         )
 
-    if use_stdin:
-        return _load_labeled_stream_from_text(
-            sys.stdin.read(),
+    label_source_count = sum(
+        1 for present in (bool(labels_input_path), bool(labels_input_json)) if present
+    )
+    if label_source_count > 1:
+        raise ValueError(
+            "Provide at most one separate labels source via --labels-input or --labels-input-json."
+        )
+
+    dataframe, source_type, label, resolved_input_path = _load_dataframe_input_source(
+        input_path=input_path,
+        input_json=input_json,
+        use_stdin=use_stdin,
+    )
+
+    label_source_ref: Optional[dict[str, Any]] = None
+    if label_source_count:
+        labels_dataframe, labels_source_type, labels_label, labels_resolved_input_path = _load_dataframe_input_source(
+            input_path=labels_input_path,
+            input_json=labels_input_json,
+            use_stdin=False,
+        )
+        dataframe, preparation = _merge_labeled_stream_sources(
+            signal_df=dataframe,
+            labels_df=labels_dataframe,
             time_col=time_col,
-            value_cols=value_cols,
             label_col=label_col,
+            labels_time_col=labels_time_col,
+            label_start_col=label_start_col,
+            label_end_col=label_end_col,
+        )
+        label_source_ref = {
+            "source_type": labels_source_type,
+            "path": labels_resolved_input_path,
+            "label": labels_label,
+            "time_column": labels_time_col,
+            "start_column": preparation.get("label_start_col"),
+            "end_column": preparation.get("label_end_col"),
+            "mode": preparation.get("mode"),
+        }
+    stream_input = _labeled_stream_input_from_dataframe(
+        dataframe,
+        source_type=source_type,
+        label=label,
+        input_path=resolved_input_path,
+        time_col=time_col,
+        value_cols=value_cols,
+        label_col=label_col,
+    )
+    if label_source_ref is not None:
+        stream_ref = stream_input.provenance.setdefault("stream_ref", {})
+        stream_ref["label_source"] = label_source_ref
+        stream_ref["preparation"] = preparation
+    return stream_input
+
+
+def _load_dataframe_input_source(
+    *,
+    input_path: Optional[str],
+    input_json: Optional[str],
+    use_stdin: bool,
+):
+    if use_stdin:
+        return _load_dataframe_from_text(
+            sys.stdin.read(),
+            source_type_json="stdin_json",
+            json_input_path="stdin.json",
+            tabular_input_path="-",
+            csv_label="stdin.csv",
         )
 
     if input_json:
@@ -223,29 +290,288 @@ def load_labeled_stream_input(
             source_type=source_type,
             input_path=input_json if source_type == "json_file" else None,
         )
-        return _labeled_stream_input_from_dataframe(
-            dataframe,
-            source_type=source_type,
-            label=label,
-            input_path=resolved_input_path,
+        return dataframe, source_type, label, resolved_input_path
+
+    if input_path is None:
+        raise RuntimeError("_load_dataframe_input_source requires an input path when no other source is set")
+
+    if input_path == "-":
+        return _load_dataframe_from_text(
+            sys.stdin.read(),
+            source_type_json="stdin_json",
+            json_input_path="stdin.json",
+            tabular_input_path="-",
+            csv_label="stdin.csv",
+        )
+
+    dataframe, source_type, label = _load_dataframe_from_path(input_path)
+    return dataframe, source_type, label, input_path
+
+
+def _load_dataframe_from_text(
+    raw_text: str,
+    *,
+    source_type_json: str,
+    json_input_path: str,
+    tabular_input_path: str,
+    csv_label: str,
+):
+    stripped = raw_text.lstrip()
+    if not stripped:
+        raise ValueError("No input data was received from stdin.")
+
+    if stripped[0] in "[{":
+        try:
+            payload = json.loads(raw_text)
+        except json.JSONDecodeError:
+            payload = None
+        if payload is not None:
+            dataframe, label, _ = _dataframe_from_json_payload(
+                payload,
+                source_type=source_type_json,
+                input_path=json_input_path,
+            )
+            return dataframe, source_type_json, label, tabular_input_path
+
+    import pandas as pd
+
+    dataframe = pd.read_csv(StringIO(raw_text))
+    return dataframe, "csv", csv_label, tabular_input_path
+
+
+def _merge_labeled_stream_sources(
+    *,
+    signal_df,
+    labels_df,
+    time_col: Optional[str],
+    label_col: str,
+    labels_time_col: Optional[str],
+    label_start_col: Optional[str],
+    label_end_col: Optional[str],
+):
+    if bool(label_start_col) ^ bool(label_end_col):
+        raise ValueError(
+            "Provide both --labels-start-col and --labels-end-col when using segment labels."
+        )
+
+    auto_start_col = label_start_col
+    auto_end_col = label_end_col
+    if auto_start_col is None and auto_end_col is None:
+        if "start" in labels_df.columns and "end" in labels_df.columns:
+            auto_start_col = "start"
+            auto_end_col = "end"
+
+    if auto_start_col and auto_end_col:
+        return _merge_segment_labels(
+            signal_df=signal_df,
+            labels_df=labels_df,
             time_col=time_col,
-            value_cols=value_cols,
+            label_col=label_col,
+            label_start_col=auto_start_col,
+            label_end_col=auto_end_col,
+        )
+
+    if len(labels_df) == len(signal_df):
+        return _merge_labels_by_row_alignment(
+            signal_df=signal_df,
+            labels_df=labels_df,
             label_col=label_col,
         )
 
-    if input_path is None:
-        raise RuntimeError("load_labeled_stream_input requires input_path when no other source is set")
+    resolved_labels_time_col = labels_time_col
+    if resolved_labels_time_col is None and time_col and time_col in labels_df.columns:
+        resolved_labels_time_col = time_col
+    if time_col and resolved_labels_time_col:
+        return _merge_labels_by_time_alignment(
+            signal_df=signal_df,
+            labels_df=labels_df,
+            time_col=time_col,
+            labels_time_col=resolved_labels_time_col,
+            label_col=label_col,
+        )
 
-    dataframe, source_type, label = _load_dataframe_from_path(input_path)
-    return _labeled_stream_input_from_dataframe(
-        dataframe,
-        source_type=source_type,
-        label=label,
-        input_path=input_path,
-        time_col=time_col,
-        value_cols=value_cols,
-        label_col=label_col,
+    raise ValueError(
+        "Separate labels input must either align row-for-row with the signal input, "
+        "include a matching time column, or provide segment boundaries via "
+        "--labels-start-col/--labels-end-col."
     )
+
+
+def _merge_labels_by_row_alignment(
+    *,
+    signal_df,
+    labels_df,
+    label_col: str,
+):
+    if label_col not in labels_df.columns:
+        raise ValueError(
+            f"Label column '{label_col}' not found in separate labels input. Available: {list(labels_df.columns)}"
+        )
+
+    merged = signal_df.drop(columns=[label_col], errors="ignore").copy()
+    merged[label_col] = labels_df[label_col].to_numpy()
+    return merged, {
+        "mode": "row_aligned_labels",
+        "signal_rows": int(len(signal_df)),
+        "label_rows": int(len(labels_df)),
+    }
+
+
+def _merge_labels_by_time_alignment(
+    *,
+    signal_df,
+    labels_df,
+    time_col: str,
+    labels_time_col: str,
+    label_col: str,
+):
+    if time_col not in signal_df.columns:
+        raise ValueError(
+            f"Time column '{time_col}' not found in signal input. Available: {list(signal_df.columns)}"
+        )
+    if labels_time_col not in labels_df.columns:
+        raise ValueError(
+            f"Labels time column '{labels_time_col}' not found. Available: {list(labels_df.columns)}"
+        )
+    if label_col not in labels_df.columns:
+        raise ValueError(
+            f"Label column '{label_col}' not found in separate labels input. Available: {list(labels_df.columns)}"
+        )
+
+    labels_subset = labels_df[[labels_time_col, label_col]].copy()
+    if bool(labels_subset[labels_time_col].duplicated().any()):
+        raise ValueError(
+            f"Separate labels input contains duplicate values in time column '{labels_time_col}'."
+        )
+
+    merged = signal_df.drop(columns=[label_col], errors="ignore").merge(
+        labels_subset,
+        how="left",
+        left_on=time_col,
+        right_on=labels_time_col,
+        validate="m:1",
+        sort=False,
+    )
+    if labels_time_col != time_col and labels_time_col in merged.columns:
+        merged = merged.drop(columns=[labels_time_col])
+
+    import pandas as pd
+
+    missing_mask = pd.isna(merged[label_col])
+    if bool(np.any(missing_mask)):
+        raise ValueError(
+            f"Separate labels input did not cover all signal rows; {int(np.sum(missing_mask))} row(s) are unlabeled."
+        )
+
+    return merged, {
+        "mode": "time_joined_labels",
+        "signal_rows": int(len(signal_df)),
+        "label_rows": int(len(labels_df)),
+        "signal_time_column": time_col,
+        "labels_time_column": labels_time_col,
+    }
+
+
+def _merge_segment_labels(
+    *,
+    signal_df,
+    labels_df,
+    time_col: Optional[str],
+    label_col: str,
+    label_start_col: str,
+    label_end_col: str,
+):
+    if label_col not in labels_df.columns:
+        raise ValueError(
+            f"Label column '{label_col}' not found in separate labels input. Available: {list(labels_df.columns)}"
+        )
+    for column in (label_start_col, label_end_col):
+        if column not in labels_df.columns:
+            raise ValueError(
+                f"Segment boundary column '{column}' not found in separate labels input. Available: {list(labels_df.columns)}"
+            )
+
+    import pandas as pd
+
+    assigned = np.empty(len(signal_df), dtype=object)
+    assigned[:] = None
+    covered = np.zeros(len(signal_df), dtype=bool)
+
+    if time_col:
+        if time_col not in signal_df.columns:
+            raise ValueError(
+                f"Time column '{time_col}' not found in signal input. Available: {list(signal_df.columns)}"
+            )
+        signal_axis = signal_df[time_col]
+        mode = "segment_time_labels"
+    else:
+        signal_axis = None
+        mode = "segment_index_labels"
+
+    for row_index, row in enumerate(labels_df.itertuples(index=False), start=1):
+        start_value = getattr(row, label_start_col)
+        end_value = getattr(row, label_end_col)
+        label_value = getattr(row, label_col)
+        if pd.isna(start_value) or pd.isna(end_value):
+            raise ValueError(
+                f"Separate labels input contains missing segment boundaries in row {row_index}."
+            )
+        if pd.isna(label_value):
+            raise ValueError(
+                f"Separate labels input contains a missing label in row {row_index}."
+            )
+
+        if signal_axis is None:
+            try:
+                start_index = int(start_value)
+                end_index = int(end_value)
+            except (TypeError, ValueError) as exc:
+                raise ValueError(
+                    "Segment boundaries must be integer row offsets when --time-col is not set."
+                ) from exc
+            if start_index < 0 or end_index > len(signal_df) or end_index <= start_index:
+                raise ValueError(
+                    f"Invalid segment bounds [{start_index}, {end_index}) for signal length {len(signal_df)}."
+                )
+            mask = np.zeros(len(signal_df), dtype=bool)
+            mask[start_index:end_index] = True
+        else:
+            try:
+                if end_value <= start_value:
+                    raise ValueError(
+                        f"Invalid segment bounds [{start_value}, {end_value}) in row {row_index}."
+                    )
+            except TypeError:
+                pass
+            mask = ((signal_axis >= start_value) & (signal_axis < end_value)).to_numpy(dtype=bool)
+            if not bool(np.any(mask)):
+                raise ValueError(
+                    f"Segment [{start_value}, {end_value}) in row {row_index} did not match any signal rows."
+                )
+
+        if bool(np.any(covered & mask)):
+            raise ValueError("Separate segment labels overlap on one or more signal rows.")
+
+        assigned[mask] = label_value
+        covered[mask] = True
+
+    unlabeled_rows = int(np.sum(~covered))
+    if unlabeled_rows:
+        raise ValueError(
+            f"Separate segment labels left {unlabeled_rows} signal row(s) unlabeled."
+        )
+
+    merged = signal_df.drop(columns=[label_col], errors="ignore").copy()
+    merged[label_col] = assigned
+    return merged, {
+        "mode": mode,
+        "signal_rows": int(len(signal_df)),
+        "label_rows": int(len(labels_df)),
+        "signal_time_column": time_col,
+        "label_start_col": label_start_col,
+        "label_end_col": label_end_col,
+        "interval_semantics": "start_inclusive_end_exclusive",
+    }
 
 
 def _load_bundled_series(

--- a/ts_agents/cli/input_parsing.py
+++ b/ts_agents/cli/input_parsing.py
@@ -354,21 +354,25 @@ def _merge_labeled_stream_sources(
             "Provide both --labels-start-col and --labels-end-col when using segment labels."
         )
 
-    auto_start_col = label_start_col
-    auto_end_col = label_end_col
-    if auto_start_col is None and auto_end_col is None:
-        if "start" in labels_df.columns and "end" in labels_df.columns:
-            auto_start_col = "start"
-            auto_end_col = "end"
-
-    if auto_start_col and auto_end_col:
+    if label_start_col and label_end_col:
         return _merge_segment_labels(
             signal_df=signal_df,
             labels_df=labels_df,
             time_col=time_col,
             label_col=label_col,
-            label_start_col=auto_start_col,
-            label_end_col=auto_end_col,
+            label_start_col=label_start_col,
+            label_end_col=label_end_col,
+        )
+
+    if labels_time_col is not None:
+        if time_col is None:
+            raise ValueError("Using --labels-time-col requires --time-col on the signal input.")
+        return _merge_labels_by_time_alignment(
+            signal_df=signal_df,
+            labels_df=labels_df,
+            time_col=time_col,
+            labels_time_col=labels_time_col,
+            label_col=label_col,
         )
 
     if len(labels_df) == len(signal_df):
@@ -378,15 +382,12 @@ def _merge_labeled_stream_sources(
             label_col=label_col,
         )
 
-    resolved_labels_time_col = labels_time_col
-    if resolved_labels_time_col is None and time_col and time_col in labels_df.columns:
-        resolved_labels_time_col = time_col
-    if time_col and resolved_labels_time_col:
+    if time_col and time_col in labels_df.columns:
         return _merge_labels_by_time_alignment(
             signal_df=signal_df,
             labels_df=labels_df,
             time_col=time_col,
-            labels_time_col=resolved_labels_time_col,
+            labels_time_col=time_col,
             label_col=label_col,
         )
 
@@ -508,10 +509,10 @@ def _merge_segment_labels(
         signal_axis = None
         mode = "segment_index_labels"
 
-    for row_index, row in enumerate(labels_df.itertuples(index=False), start=1):
-        start_value = getattr(row, label_start_col)
-        end_value = getattr(row, label_end_col)
-        label_value = getattr(row, label_col)
+    for row_index, (_, row) in enumerate(labels_df.iterrows(), start=1):
+        start_value = row[label_start_col]
+        end_value = row[label_end_col]
+        label_value = row[label_col]
         if pd.isna(start_value) or pd.isna(end_value):
             raise ValueError(
                 f"Separate labels input contains missing segment boundaries in row {row_index}."

--- a/ts_agents/cli/main.py
+++ b/ts_agents/cli/main.py
@@ -1437,6 +1437,36 @@ def _add_workflow_subcommands(subparsers: argparse._SubParsersAction) -> None:
         help="Label column containing per-timepoint activity labels",
     )
     activity_parser.add_argument(
+        "--labels-input",
+        type=str,
+        default=None,
+        help="Optional separate labels file (row-aligned, time-aligned, or segment annotations)",
+    )
+    activity_parser.add_argument(
+        "--labels-input-json",
+        type=str,
+        default=None,
+        help="Optional separate labels JSON payload or path to a JSON file",
+    )
+    activity_parser.add_argument(
+        "--labels-time-col",
+        type=str,
+        default=None,
+        help="Time column in the separate labels input for pointwise time joins",
+    )
+    activity_parser.add_argument(
+        "--labels-start-col",
+        type=str,
+        default=None,
+        help="Segment start column in the separate labels input; intervals are [start, end)",
+    )
+    activity_parser.add_argument(
+        "--labels-end-col",
+        type=str,
+        default=None,
+        help="Segment end column in the separate labels input; intervals are [start, end)",
+    )
+    activity_parser.add_argument(
         "--value-cols",
         type=_split_csv,
         default=["x", "y", "z"],
@@ -1461,6 +1491,12 @@ def _add_workflow_subcommands(subparsers: argparse._SubParsersAction) -> None:
         help="Classifier: auto | minirocket | rocket | knn",
     )
     activity_parser.add_argument(
+        "--labeling",
+        type=str,
+        default="strict",
+        help="Window labeling: strict | majority",
+    )
+    activity_parser.add_argument(
         "--balance",
         type=str,
         default="segment_cap",
@@ -1477,6 +1513,18 @@ def _add_workflow_subcommands(subparsers: argparse._SubParsersAction) -> None:
         type=float,
         default=0.25,
         help="Test fraction per split",
+    )
+    activity_parser.add_argument(
+        "--stride",
+        type=int,
+        default=None,
+        help="Window stride (default: window_size // 2 for each candidate)",
+    )
+    activity_parser.add_argument(
+        "--n-splits",
+        type=int,
+        default=3,
+        help="Number of grouped splits for window selection and final evaluation",
     )
     activity_parser.add_argument(
         "--seed",
@@ -1597,6 +1645,12 @@ def _add_demo_subcommands(subparsers: argparse._SubParsersAction) -> None:
         help="Classifier: auto | minirocket | rocket | knn",
     )
     window_parser.add_argument(
+        "--labeling",
+        type=str,
+        default="strict",
+        help="Window labeling: strict | majority",
+    )
+    window_parser.add_argument(
         "--balance",
         type=str,
         default="segment_cap",
@@ -1613,6 +1667,18 @@ def _add_demo_subcommands(subparsers: argparse._SubParsersAction) -> None:
         type=float,
         default=0.25,
         help="Test fraction per split",
+    )
+    window_parser.add_argument(
+        "--stride",
+        type=int,
+        default=None,
+        help="Window stride (default: window_size // 2 for each candidate)",
+    )
+    window_parser.add_argument(
+        "--n-splits",
+        type=int,
+        default=3,
+        help="Number of grouped splits for window selection and final evaluation",
     )
     window_parser.add_argument(
         "--output-dir",
@@ -2847,6 +2913,9 @@ def _run_demo_window_classification_scripted(args: argparse.Namespace) -> Dict[s
     from ts_agents.cli.output import write_output
     from ts_agents.workflows.activity import run_activity_recognition_workflow
 
+    labeling = getattr(args, "labeling", "strict")
+    stride = getattr(args, "stride", None)
+    n_splits = getattr(args, "n_splits", 3)
     csv_path = Path(args.csv_path)
     output_dir = Path(args.output_dir)
     output_dir.mkdir(parents=True, exist_ok=True)
@@ -2866,9 +2935,12 @@ def _run_demo_window_classification_scripted(args: argparse.Namespace) -> Dict[s
         window_sizes=_split_int_csv(args.window_sizes) if args.window_sizes else None,
         metric=args.metric,
         classifier=args.classifier,
+        labeling=labeling,
         balance=args.balance,
         max_windows_per_segment=args.max_windows_per_segment,
         test_size=args.test_size,
+        stride=stride,
+        n_splits=n_splits,
         seed=args.seed,
         skip_plots=args.skip_plots,
     )
@@ -2933,6 +3005,9 @@ def _run_demo_window_classification_llm(args: argparse.Namespace) -> Dict[str, A
     window_sizes = [int(v) for v in _split_csv(args.window_sizes)] if args.window_sizes else None
     classifier_hint = args.classifier if args.classifier != "auto" else "choose one"
     window_sizes_text = window_sizes if window_sizes else "auto"
+    labeling = getattr(args, "labeling", "strict")
+    stride = getattr(args, "stride", None)
+    n_splits = getattr(args, "n_splits", 3)
 
     prompt = (
         "You are running the ts-agents demo. Use tools to:\n"
@@ -2943,9 +3018,12 @@ def _run_demo_window_classification_llm(args: argparse.Namespace) -> Dict[str, A
         f"label_column: {args.label_column}\n"
         f"window_sizes: {window_sizes_text}\n"
         f"metric: {args.metric}\n"
+        f"labeling: {labeling}\n"
         f"balance: {args.balance}\n"
         f"max_windows_per_segment: {args.max_windows_per_segment}\n"
         f"test_size: {args.test_size}\n"
+        f"stride: {stride if stride is not None else 'auto'}\n"
+        f"n_splits: {n_splits}\n"
         f"seed: {args.seed}\n"
         f"classifier: {classifier_hint} (minirocket|rocket|knn)\n\n"
         "After the tool calls, write a short Markdown report with:\n"

--- a/ts_agents/core/base.py
+++ b/ts_agents/core/base.py
@@ -198,6 +198,7 @@ class ClassificationResult(AnalysisResult):
     accuracy: Optional[float] = None
     f1_score: Optional[float] = None
     confusion_matrix: Optional[np.ndarray] = None
+    warnings: List[str] = field(default_factory=list)
 
 
 # =============================================================================

--- a/ts_agents/core/classification/convolution.py
+++ b/ts_agents/core/classification/convolution.py
@@ -63,7 +63,7 @@ def rocket_classify(
             MiniRocketClassifier,
             MultiRocketClassifier,
         )
-    except ImportError:
+    except Exception:
         return _fallback_rocket_classify(X_train, y_train, X_test, y_test)
 
     # Ensure 3D format
@@ -82,13 +82,16 @@ def rocket_classify(
 
     # Different parameter names for different variants
     try:
-        clf = clf_class(num_kernels=n_kernels)
-    except TypeError:
-        # Some variants use different parameter names
-        clf = clf_class()
+        try:
+            clf = clf_class(num_kernels=n_kernels)
+        except TypeError:
+            # Some variants use different parameter names
+            clf = clf_class()
 
-    clf.fit(X_train, y_train)
-    predictions = clf.predict(X_test)
+        clf.fit(X_train, y_train)
+        predictions = clf.predict(X_test)
+    except Exception:
+        return _fallback_rocket_classify(X_train, y_train, X_test, y_test)
 
     # Get probabilities
     probabilities = None

--- a/ts_agents/core/classification/convolution.py
+++ b/ts_agents/core/classification/convolution.py
@@ -11,6 +11,13 @@ from ..base import ClassificationResult
 from .utils import ensure_3d
 
 
+def _rocket_fallback_warning(context: str, exc: Exception) -> str:
+    return (
+        "ROCKET backend fallback activated during "
+        f"{context}: {type(exc).__name__}: {exc}"
+    )
+
+
 def rocket_classify(
     X_train: np.ndarray,
     y_train: np.ndarray,
@@ -63,8 +70,14 @@ def rocket_classify(
             MiniRocketClassifier,
             MultiRocketClassifier,
         )
-    except Exception:
-        return _fallback_rocket_classify(X_train, y_train, X_test, y_test)
+    except Exception as exc:
+        return _fallback_rocket_classify(
+            X_train,
+            y_train,
+            X_test,
+            y_test,
+            warning_message=_rocket_fallback_warning("import", exc),
+        )
 
     # Ensure 3D format
     X_train = ensure_3d(X_train)
@@ -90,8 +103,14 @@ def rocket_classify(
 
         clf.fit(X_train, y_train)
         predictions = clf.predict(X_test)
-    except Exception:
-        return _fallback_rocket_classify(X_train, y_train, X_test, y_test)
+    except Exception as exc:
+        return _fallback_rocket_classify(
+            X_train,
+            y_train,
+            X_test,
+            y_test,
+            warning_message=_rocket_fallback_warning("fit/predict", exc),
+        )
 
     # Get probabilities
     probabilities = None
@@ -120,6 +139,7 @@ def _fallback_rocket_classify(
     y_train: np.ndarray,
     X_test: np.ndarray,
     y_test: Optional[np.ndarray] = None,
+    warning_message: Optional[str] = None,
 ) -> ClassificationResult:
     """Fallback implementation when aeon is not available."""
     from sklearn.linear_model import RidgeClassifierCV
@@ -168,6 +188,7 @@ def _fallback_rocket_classify(
         predictions=predictions,
         probabilities=None,
         accuracy=accuracy,
+        warnings=[warning_message] if warning_message else [],
     )
 
 

--- a/ts_agents/core/classification/distance_based.py
+++ b/ts_agents/core/classification/distance_based.py
@@ -11,6 +11,13 @@ from ..base import ClassificationResult
 from .utils import ensure_3d
 
 
+def _knn_fallback_warning(context: str, exc: Exception) -> str:
+    return (
+        "Time-series KNN backend fallback activated during "
+        f"{context}: {type(exc).__name__}: {exc}"
+    )
+
+
 def knn_classify(
     X_train: np.ndarray,
     y_train: np.ndarray,
@@ -62,8 +69,14 @@ def knn_classify(
     """
     try:
         from aeon.classification.distance_based import KNeighborsTimeSeriesClassifier
-    except Exception:
-        return _fallback_knn_classify(X_train, y_train, X_test, y_test)
+    except Exception as exc:
+        return _fallback_knn_classify(
+            X_train,
+            y_train,
+            X_test,
+            y_test,
+            warning_message=_knn_fallback_warning("import", exc),
+        )
 
     # Ensure 3D format for aeon
     X_train = ensure_3d(X_train)
@@ -78,8 +91,14 @@ def knn_classify(
         )
         clf.fit(X_train, y_train)
         predictions = clf.predict(X_test)
-    except Exception:
-        return _fallback_knn_classify(X_train, y_train, X_test, y_test)
+    except Exception as exc:
+        return _fallback_knn_classify(
+            X_train,
+            y_train,
+            X_test,
+            y_test,
+            warning_message=_knn_fallback_warning("fit/predict", exc),
+        )
 
     # Get probabilities if available
     probabilities = None
@@ -108,6 +127,7 @@ def _fallback_knn_classify(
     y_train: np.ndarray,
     X_test: np.ndarray,
     y_test: Optional[np.ndarray] = None,
+    warning_message: Optional[str] = None,
 ) -> ClassificationResult:
     """Fallback KNN implementation when aeon is not available."""
     from sklearn.neighbors import KNeighborsClassifier
@@ -131,6 +151,7 @@ def _fallback_knn_classify(
         predictions=predictions,
         probabilities=probabilities,
         accuracy=accuracy,
+        warnings=[warning_message] if warning_message else [],
     )
 
 

--- a/ts_agents/core/classification/distance_based.py
+++ b/ts_agents/core/classification/distance_based.py
@@ -62,7 +62,7 @@ def knn_classify(
     """
     try:
         from aeon.classification.distance_based import KNeighborsTimeSeriesClassifier
-    except ImportError:
+    except Exception:
         return _fallback_knn_classify(X_train, y_train, X_test, y_test)
 
     # Ensure 3D format for aeon
@@ -70,14 +70,16 @@ def knn_classify(
     X_test = ensure_3d(X_test)
     y_train = np.asarray(y_train)
 
-    clf = KNeighborsTimeSeriesClassifier(
-        distance=distance,
-        n_neighbors=n_neighbors,
-        weights=weights,
-    )
-    clf.fit(X_train, y_train)
-
-    predictions = clf.predict(X_test)
+    try:
+        clf = KNeighborsTimeSeriesClassifier(
+            distance=distance,
+            n_neighbors=n_neighbors,
+            weights=weights,
+        )
+        clf.fit(X_train, y_train)
+        predictions = clf.predict(X_test)
+    except Exception:
+        return _fallback_knn_classify(X_train, y_train, X_test, y_test)
 
     # Get probabilities if available
     probabilities = None

--- a/ts_agents/core/windowing/selection.py
+++ b/ts_agents/core/windowing/selection.py
@@ -23,7 +23,7 @@ Key features
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, Dict, Iterable, List, Literal, Optional, Sequence, Tuple, Union
 
 import numpy as np
@@ -57,6 +57,11 @@ class WindowedClassificationEvaluation(AnalysisResult):
     n_windows: int
     class_counts: Dict[str, int]
     classification: Dict[str, Any]
+    n_splits: int = 1
+    split_scores: List[float] = field(default_factory=list)
+    retained_classes: List[str] = field(default_factory=list)
+    dropped_classes: List[str] = field(default_factory=list)
+    details: Dict[str, Any] = field(default_factory=dict)
 
 
 MetricName = Literal["accuracy", "balanced_accuracy", "f1_macro"]
@@ -296,6 +301,68 @@ def _balanced_accuracy_safe(y_true: np.ndarray, y_pred: np.ndarray) -> float:
     return float(np.mean(recalls))
 
 
+def _class_count_dict(labels: np.ndarray) -> Dict[str, int]:
+    if labels.size == 0:
+        return {}
+    unique, counts = np.unique(labels, return_counts=True)
+    return {str(label): int(count) for label, count in zip(unique, counts)}
+
+
+def _class_retention_summary(all_labels: np.ndarray, retained_labels: np.ndarray) -> Dict[str, Any]:
+    all_classes = [str(label) for label in np.unique(all_labels)]
+    retained_classes = [str(label) for label in np.unique(retained_labels)] if retained_labels.size else []
+    retained_lookup = set(retained_classes)
+    dropped_classes = [label for label in all_classes if label not in retained_lookup]
+    retained_fraction = (
+        float(len(retained_classes) / len(all_classes))
+        if all_classes
+        else 0.0
+    )
+    return {
+        "all_classes": all_classes,
+        "retained_classes": retained_classes,
+        "dropped_classes": dropped_classes,
+        "retained_class_fraction": retained_fraction,
+    }
+
+
+def _run_window_classifier(
+    *,
+    classifier: ClassifierName,
+    X_train: np.ndarray,
+    y_train: np.ndarray,
+    X_test: np.ndarray,
+    y_test: np.ndarray,
+    rocket_n_kernels: int,
+):
+    X_train_3d = _to_classifier_input(X_train)
+    X_test_3d = _to_classifier_input(X_test)
+
+    if classifier in {"rocket", "minirocket"}:
+        variant = "minirocket" if classifier == "minirocket" else "rocket"
+        clf_res = rocket_classify(
+            X_train_3d,
+            y_train,
+            X_test_3d,
+            y_test,
+            variant=variant,
+            n_kernels=rocket_n_kernels,
+        )
+    elif classifier == "knn":
+        clf_res = knn_classify(
+            X_train_3d,
+            y_train,
+            X_test_3d,
+            y_test,
+            distance="dtw",
+            n_neighbors=1,
+        )
+    else:
+        raise ValueError(f"Unknown classifier: {classifier}")
+
+    return np.asarray(clf_res.predictions), clf_res
+
+
 def _iter_valid_group_splits(
     X: np.ndarray,
     y: np.ndarray,
@@ -446,10 +513,12 @@ def select_window_size(
         raise ValueError("No valid candidate window sizes")
 
     rng = np.random.default_rng(random_state)
+    original_classes = np.unique(labels_1d)
 
     scores_by_window: Dict[int, float] = {}
     n_windows_by_window: Dict[int, int] = {}
     split_scores: Dict[int, List[float]] = {}
+    window_diagnostics: Dict[int, Dict[str, Any]] = {}
 
     for w in window_sizes:
         s = stride if stride is not None else max(1, w // 2)
@@ -471,9 +540,21 @@ def select_window_size(
         )
 
         n_windows_by_window[w] = int(X.shape[0])
+        retention = _class_retention_summary(original_classes, y)
+        window_diagnostics[w] = {
+            "window_size": int(w),
+            "stride": int(s),
+            "n_windows": int(X.shape[0]),
+            "class_counts": _class_count_dict(y),
+            "retained_classes": retention["retained_classes"],
+            "dropped_classes": retention["dropped_classes"],
+            "retained_class_fraction": retention["retained_class_fraction"],
+        }
         if X.shape[0] < 10:
             # Not enough data to evaluate.
             scores_by_window[w] = float("nan")
+            split_scores[w] = []
+            window_diagnostics[w]["valid_split_count"] = 0
             continue
 
         fold_scores: List[float] = []
@@ -492,37 +573,19 @@ def select_window_size(
             X_test = X[test_idx]
             y_test = y[test_idx]
 
-            X_train_3d = _to_classifier_input(X_train)
-            X_test_3d = _to_classifier_input(X_test)
-
-            if classifier in {"rocket", "minirocket"}:
-                variant = "minirocket" if classifier == "minirocket" else "rocket"
-                clf_res = rocket_classify(
-                    X_train_3d,
-                    y_train,
-                    X_test_3d,
-                    y_test,
-                    variant=variant,
-                    n_kernels=rocket_n_kernels,
-                )
-                y_pred = np.asarray(clf_res.predictions)
-            elif classifier == "knn":
-                clf_res = knn_classify(
-                    X_train_3d,
-                    y_train,
-                    X_test_3d,
-                    y_test,
-                    distance="dtw",
-                    n_neighbors=1,
-                )
-                y_pred = np.asarray(clf_res.predictions)
-            else:
-                raise ValueError(f"Unknown classifier: {classifier}")
-
+            y_pred, _ = _run_window_classifier(
+                classifier=classifier,
+                X_train=X_train,
+                y_train=y_train,
+                X_test=X_test,
+                y_test=y_test,
+                rocket_n_kernels=rocket_n_kernels,
+            )
             fold_scores.append(_score_metric(metric, y_test, y_pred))
 
         split_scores[w] = fold_scores
         scores_by_window[w] = float(np.nanmean(fold_scores)) if fold_scores else float("nan")
+        window_diagnostics[w]["valid_split_count"] = len(fold_scores)
 
     # Choose best (highest score), ignoring NaNs.
     best_w = None
@@ -551,7 +614,9 @@ def select_window_size(
             "max_windows_per_segment": max_windows_per_segment,
             "n_splits": n_splits,
             "test_size": test_size,
+            "all_classes": [str(label) for label in original_classes],
             "split_scores": {int(k): [float(x) for x in v] for k, v in split_scores.items()},
+            "window_diagnostics": {int(k): v for k, v in window_diagnostics.items()},
         },
     )
 
@@ -561,38 +626,41 @@ def select_window_size_from_csv(
     *,
     value_columns: Union[str, List[str]] = "value",
     label_column: str = "label",
+    time_column: Optional[str] = None,
     **kwargs: Any,
 ) -> WindowSizeSelectionResult:
-    """Convenience wrapper around :func:`select_window_size` for CSV inputs.
+    """Convenience wrapper around :func:`select_window_size` for tabular inputs.
 
-    The CSV is expected to contain one row per timepoint.
+    The historical ``csv_path`` parameter accepts any tabular path supported by
+    :func:`ts_agents.cli.input_parsing.load_labeled_stream_input`.
 
     Parameters
     ----------
     csv_path
-        Path to CSV.
+        Path to a tabular file.
     value_columns
         Column name (or list of column names) containing the time series value(s).
     label_column
         Column name containing the per-timepoint label.
+    time_column
+        Optional time/index column for the tabular input.
     kwargs
         Forwarded to :func:`select_window_size`.
     """
+    from ts_agents.cli.input_parsing import load_labeled_stream_input
 
-    df = pd.read_csv(csv_path)
-    if isinstance(value_columns, str):
-        if "," in value_columns:
-            cols = [c.strip() for c in value_columns.split(",") if c.strip()]
-        else:
-            cols = [value_columns]
-    else:
-        cols = list(value_columns)
-    for c in cols + [label_column]:
-        if c not in df.columns:
-            raise ValueError(f"Column '{c}' not found in {csv_path}. Available: {list(df.columns)}")
-    series = df[cols].to_numpy()
-    labels = df[label_column].to_numpy()
-    return select_window_size(series, labels, **kwargs)
+    cols = (
+        [c.strip() for c in value_columns.split(",") if c.strip()]
+        if isinstance(value_columns, str)
+        else list(value_columns)
+    )
+    stream_input = load_labeled_stream_input(
+        input_path=csv_path,
+        time_col=time_column,
+        value_cols=cols,
+        label_col=label_column,
+    )
+    return select_window_size(stream_input.values, stream_input.labels, **kwargs)
 
 
 def evaluate_windowed_classifier(
@@ -603,11 +671,14 @@ def evaluate_windowed_classifier(
     stride: Optional[int] = None,
     classifier: ClassifierName = "minirocket",
     metric: MetricName = "balanced_accuracy",
+    labeling: LabelingStrategy = "strict",
     balance: BalanceStrategy = "segment_cap",
     max_windows_per_segment: Optional[int] = 25,
+    n_splits: int = 1,
     test_size: float = 0.2,
     seed: int = 1337,
     rocket_n_kernels: int = 2000,
+    min_label_purity: float = 0.8,
 ) -> WindowedClassificationEvaluation:
     """Evaluate a classifier on sliding windows extracted from a labeled stream.
 
@@ -625,14 +696,15 @@ def evaluate_windowed_classifier(
     if not segments:
         raise ValueError("labels produced no segments")
 
+    original_classes = np.unique(labels1d)
     stride_value = stride if stride is not None else max(1, window_size // 2)
     X, y, groups = _extract_windows_from_segments(
         series2d,
         segments,
         window_size=window_size,
         stride=stride_value,
-        labeling="strict",
-        min_purity=0.9,
+        labeling=labeling,
+        min_purity=min_label_purity,
         labels=labels1d,
     )
 
@@ -658,7 +730,7 @@ def evaluate_windowed_classifier(
         X,
         y,
         groups,
-        n_splits=1,
+        n_splits=n_splits,
         test_size=test_size,
         random_state=seed,
         min_classes_per_split=min_classes,
@@ -666,46 +738,42 @@ def evaluate_windowed_classifier(
     if not splits:
         raise ValueError("Unable to construct a valid train/test split from extracted windows")
 
-    train_idx, test_idx = splits[0]
-    X_train, X_test = X[train_idx], X[test_idx]
-    y_train, y_test = y[train_idx], y[test_idx]
-
-    X_train_3d = _to_classifier_input(X_train)
-    X_test_3d = _to_classifier_input(X_test)
-
-    if classifier in ("minirocket", "rocket"):
-        variant = "minirocket" if classifier == "minirocket" else "rocket"
-        clf_res = rocket_classify(
-            X_train_3d,
-            y_train,
-            X_test_3d,
-            y_test,
-            variant=variant,
-            n_kernels=rocket_n_kernels,
+    split_scores: List[float] = []
+    pooled_true: List[np.ndarray] = []
+    pooled_pred: List[np.ndarray] = []
+    classification_method: Optional[str] = None
+    for train_idx, test_idx in splits:
+        X_train, X_test = X[train_idx], X[test_idx]
+        y_train, y_test = y[train_idx], y[test_idx]
+        y_pred, clf_res = _run_window_classifier(
+            classifier=classifier,
+            X_train=X_train,
+            y_train=y_train,
+            X_test=X_test,
+            y_test=y_test,
+            rocket_n_kernels=rocket_n_kernels,
         )
-    elif classifier == "knn":
-        clf_res = knn_classify(
-            X_train_3d,
-            y_train,
-            X_test_3d,
-            y_test,
-            distance="dtw",
-        )
-    else:
-        raise ValueError(f"Unknown classifier: {classifier}")
+        split_scores.append(_score_metric(metric, y_test, y_pred))
+        pooled_true.append(np.asarray(y_test))
+        pooled_pred.append(np.asarray(y_pred))
+        if classification_method is None:
+            classification_method = str(getattr(clf_res, "method", classifier))
 
-    y_pred = np.asarray(clf_res.predictions)
-    score = _score_metric(metric, y_test, y_pred)
+    y_true = np.concatenate(pooled_true, axis=0)
+    y_pred = np.concatenate(pooled_pred, axis=0)
+    score = float(np.nanmean(split_scores)) if split_scores else 0.0
 
-    labels_order = np.unique(np.concatenate([y_train, y_test, y_pred]))
+    labels_order = np.unique(np.concatenate([y_true, y_pred]))
     accuracy_score, f1_score, confusion_matrix, _ = _get_sklearn_windowing_tools()
-    clf_res.accuracy = float(accuracy_score(y_test, y_pred))
-    clf_res.f1_score = float(f1_score(y_test, y_pred, average="macro", zero_division=0))
-    clf_res.confusion_matrix = confusion_matrix(y_test, y_pred, labels=labels_order)
-
-    # Make class-counts JSON-friendly.
-    unique, counts = np.unique(y, return_counts=True)
-    class_counts = {str(k): int(v) for k, v in zip(unique, counts)}
+    retention = _class_retention_summary(original_classes, y)
+    classification = {
+        "method": classification_method or str(classifier),
+        "predictions": y_pred.tolist(),
+        "accuracy": float(accuracy_score(y_true, y_pred)),
+        "f1_score": float(f1_score(y_true, y_pred, average="macro", zero_division=0)),
+        "confusion_matrix": confusion_matrix(y_true, y_pred, labels=labels_order).tolist(),
+    }
+    class_counts = _class_count_dict(y)
 
     return WindowedClassificationEvaluation(
         method="windowed_classification",
@@ -716,7 +784,21 @@ def evaluate_windowed_classifier(
         score=float(score),
         n_windows=int(X.shape[0]),
         class_counts=class_counts,
-        classification=clf_res.to_dict() if hasattr(clf_res, "to_dict") else dict(clf_res),
+        classification=classification,
+        n_splits=len(splits),
+        split_scores=[float(value) for value in split_scores],
+        retained_classes=retention["retained_classes"],
+        dropped_classes=retention["dropped_classes"],
+        details={
+            "labeling": labeling,
+            "balance": balance,
+            "max_windows_per_segment": cap,
+            "requested_n_splits": int(n_splits),
+            "valid_split_count": int(len(splits)),
+            "retained_class_fraction": retention["retained_class_fraction"],
+            "all_classes": retention["all_classes"],
+            "test_class_counts": _class_count_dict(y_true),
+        },
     )
 
 
@@ -726,21 +808,26 @@ def evaluate_windowed_classifier_from_csv(
     window_size: int,
     value_columns: Union[str, List[str]] = "value",
     label_column: str = "label",
+    time_column: Optional[str] = None,
     **kwargs: Any,
 ) -> WindowedClassificationEvaluation:
-    """CSV wrapper for :func:`evaluate_windowed_classifier`."""
+    """Tabular-file wrapper for :func:`evaluate_windowed_classifier`."""
+    from ts_agents.cli.input_parsing import load_labeled_stream_input
 
-    df = pd.read_csv(csv_path)
-    if isinstance(value_columns, str):
-        if "," in value_columns:
-            cols = [c.strip() for c in value_columns.split(",") if c.strip()]
-        else:
-            cols = [value_columns]
-    else:
-        cols = list(value_columns)
-    for c in cols + [label_column]:
-        if c not in df.columns:
-            raise ValueError(f"Column '{c}' not found in {csv_path}. Available: {list(df.columns)}")
-    series = df[cols].to_numpy()
-    labels = df[label_column].to_numpy()
-    return evaluate_windowed_classifier(series, labels, window_size=window_size, **kwargs)
+    cols = (
+        [c.strip() for c in value_columns.split(",") if c.strip()]
+        if isinstance(value_columns, str)
+        else list(value_columns)
+    )
+    stream_input = load_labeled_stream_input(
+        input_path=csv_path,
+        time_col=time_column,
+        value_cols=cols,
+        label_col=label_column,
+    )
+    return evaluate_windowed_classifier(
+        stream_input.values,
+        stream_input.labels,
+        window_size=window_size,
+        **kwargs,
+    )

--- a/ts_agents/core/windowing/selection.py
+++ b/ts_agents/core/windowing/selection.py
@@ -742,6 +742,7 @@ def evaluate_windowed_classifier(
     pooled_true: List[np.ndarray] = []
     pooled_pred: List[np.ndarray] = []
     classification_method: Optional[str] = None
+    classification_warnings: List[str] = []
     for train_idx, test_idx in splits:
         X_train, X_test = X[train_idx], X[test_idx]
         y_train, y_test = y[train_idx], y[test_idx]
@@ -758,6 +759,9 @@ def evaluate_windowed_classifier(
         pooled_pred.append(np.asarray(y_pred))
         if classification_method is None:
             classification_method = str(getattr(clf_res, "method", classifier))
+        for warning in getattr(clf_res, "warnings", []) or []:
+            if warning not in classification_warnings:
+                classification_warnings.append(str(warning))
 
     y_true = np.concatenate(pooled_true, axis=0)
     y_pred = np.concatenate(pooled_pred, axis=0)
@@ -773,6 +777,8 @@ def evaluate_windowed_classifier(
         "f1_score": float(f1_score(y_true, y_pred, average="macro", zero_division=0)),
         "confusion_matrix": confusion_matrix(y_true, y_pred, labels=labels_order).tolist(),
     }
+    if classification_warnings:
+        classification["warnings"] = classification_warnings
     class_counts = _class_count_dict(y)
 
     return WindowedClassificationEvaluation(

--- a/ts_agents/resources/skills/activity-recognition/SKILL.md
+++ b/ts_agents/resources/skills/activity-recognition/SKILL.md
@@ -63,6 +63,20 @@ This:
 3. writes plots into `outputs/activity-recognition/`
 4. writes a short report to `outputs/activity-recognition/report.md`
 
+If signals and labels live in separate files, the workflow can prepare the labeled stream directly:
+
+```bash
+uv run ts-agents workflow run activity-recognition \
+  --input signals.csv \
+  --time-col ts \
+  --value-cols x,y,z \
+  --labels-input segments.csv \
+  --labels-start-col start \
+  --labels-end-col end \
+  --label-col activity \
+  --output-dir outputs/activity-recognition
+```
+
 ## Customize the workflow
 
 ```bash
@@ -73,6 +87,9 @@ uv run ts-agents workflow run activity-recognition \
   --window-sizes 32,64,128 \
   --classifier minirocket \
   --metric balanced_accuracy \
+  --labeling majority \
+  --stride 16 \
+  --n-splits 5 \
   --output-dir outputs/activity-recognition
 ```
 

--- a/ts_agents/tools/registry.py
+++ b/ts_agents/tools/registry.py
@@ -1503,13 +1503,13 @@ def _register_default_tools() -> None:
 
     _register_tool(
         name="select_window_size_from_csv",
-        description="Window-size selection from a CSV with columns for values and labels.",
+        description="Window-size selection from a tabular file with columns for values and labels.",
         category=ToolCategory.CLASSIFICATION,
         cost=ComputationalCost.HIGH,
         core_function=select_window_size_from_csv,
         dependencies=["pandas", "numpy", "scikit-learn"],
         parameters=[
-            ToolParameter("csv_path", "str", "Path to CSV (one row per timepoint)"),
+            ToolParameter("csv_path", "str", "Path to a tabular file (one row per timepoint)"),
             ToolParameter(
                 "value_columns",
                 "str | list[str]",
@@ -1524,6 +1524,7 @@ def _register_default_tools() -> None:
                 optional=True,
                 default="label",
             ),
+            ToolParameter("time_column", "str", "Optional time/index column", optional=True, default=None),
             # Forwarded kwargs (must be whitelisted to pass tool validation)
             ToolParameter("window_sizes", "list[int]", "Candidate window sizes", optional=True),
             ToolParameter("min_window", "int", "Minimum window size", optional=True, default=16),
@@ -1572,6 +1573,7 @@ def _register_default_tools() -> None:
                 optional=True,
                 default="balanced_accuracy",
             ),
+            ToolParameter("labeling", "str", "strict|majority", optional=True, default="strict"),
             ToolParameter("balance", "str", "none|undersample|segment_cap", optional=True, default="segment_cap"),
             ToolParameter(
                 "max_windows_per_segment",
@@ -1580,6 +1582,7 @@ def _register_default_tools() -> None:
                 optional=True,
                 default=25,
             ),
+            ToolParameter("n_splits", "int", "Number of grouped splits", optional=True, default=1),
             ToolParameter("test_size", "float", "Test fraction", optional=True, default=0.2),
             ToolParameter("seed", "int", "Random seed", optional=True, default=1337),
             ToolParameter("rocket_n_kernels", "int", "Kernels", optional=True, default=2000),
@@ -1597,13 +1600,13 @@ def _register_default_tools() -> None:
 
     _register_tool(
         name="evaluate_windowed_classifier_from_csv",
-        description="Evaluate a classifier on sliding windows extracted from a labeled CSV.",
+        description="Evaluate a classifier on sliding windows extracted from a labeled tabular file.",
         category=ToolCategory.CLASSIFICATION,
         cost=ComputationalCost.HIGH,
         core_function=evaluate_windowed_classifier_from_csv,
         dependencies=["pandas", "numpy", "scikit-learn", "aeon"],
         parameters=[
-            ToolParameter("csv_path", "str", "Path to CSV (one row per timepoint)"),
+            ToolParameter("csv_path", "str", "Path to a tabular file (one row per timepoint)"),
             ToolParameter("window_size", "int", "Window size"),
             ToolParameter(
                 "value_columns",
@@ -1613,6 +1616,7 @@ def _register_default_tools() -> None:
                 default="value",
             ),
             ToolParameter("label_column", "str", "Label column name", optional=True, default="label"),
+            ToolParameter("time_column", "str", "Optional time/index column", optional=True, default=None),
             ToolParameter("stride", "int", "Stride", optional=True),
             ToolParameter("classifier", "str", "minirocket|rocket|knn", optional=True, default="minirocket"),
             ToolParameter(
@@ -1622,6 +1626,7 @@ def _register_default_tools() -> None:
                 optional=True,
                 default="balanced_accuracy",
             ),
+            ToolParameter("labeling", "str", "strict|majority", optional=True, default="strict"),
             ToolParameter("balance", "str", "none|undersample|segment_cap", optional=True, default="segment_cap"),
             ToolParameter(
                 "max_windows_per_segment",
@@ -1630,6 +1635,7 @@ def _register_default_tools() -> None:
                 optional=True,
                 default=25,
             ),
+            ToolParameter("n_splits", "int", "Number of grouped splits", optional=True, default=1),
             ToolParameter("test_size", "float", "Test fraction", optional=True, default=0.2),
             ToolParameter("seed", "int", "Random seed", optional=True, default=1337),
             ToolParameter("rocket_n_kernels", "int", "Kernels", optional=True, default=2000),

--- a/ts_agents/workflows/__init__.py
+++ b/ts_agents/workflows/__init__.py
@@ -324,6 +324,11 @@ def _load_activity_workflow_input(args: Any):
         time_col=getattr(args, "time_col", None),
         value_cols=getattr(args, "value_cols", None),
         label_col=getattr(args, "label_col", "label"),
+        labels_input_path=getattr(args, "labels_input", None),
+        labels_input_json=getattr(args, "labels_input_json", None),
+        labels_time_col=getattr(args, "labels_time_col", None),
+        label_start_col=getattr(args, "labels_start_col", None),
+        label_end_col=getattr(args, "labels_end_col", None),
     )
 
 
@@ -357,9 +362,12 @@ def _build_activity_runner_kwargs(args: Any) -> Dict[str, Any]:
         "window_sizes": getattr(args, "window_sizes", None),
         "metric": args.metric,
         "classifier": args.classifier,
+        "labeling": args.labeling,
         "balance": args.balance,
         "max_windows_per_segment": args.max_windows_per_segment,
         "test_size": args.test_size,
+        "stride": args.stride,
+        "n_splits": args.n_splits,
         "seed": args.seed,
         "skip_plots": args.skip_plots,
     }
@@ -596,11 +604,29 @@ _WORKFLOWS = {
         runner=run_activity_recognition_workflow,
         load_input=_load_activity_workflow_input,
         build_runner_kwargs=_build_activity_runner_kwargs,
-        source_requirement="Exactly one of --input, --input-json, or --stdin is required.",
+        source_requirement=(
+            "Exactly one of --input, --input-json, or --stdin is required. "
+            "Use --labels-input/--labels-input-json for an optional separate labels table."
+        ),
         supported_input_modes=["input_file", "input_json", "stdin"],
         options=[
             WorkflowOption("output_dir", "string", "Output directory for workflow artifacts.", default="outputs/activity"),
             WorkflowOption("label_col", "string", "Label column containing activity labels.", default="label"),
+            WorkflowOption("labels_input", "string", "Optional separate labels file.", default=None),
+            WorkflowOption("labels_input_json", "string", "Optional separate labels JSON payload or file path.", default=None),
+            WorkflowOption("labels_time_col", "string", "Time column in separate labels input for pointwise joins.", default=None),
+            WorkflowOption(
+                "labels_start_col",
+                "string",
+                "Segment start column in separate labels input; intervals are [start, end).",
+                default=None,
+            ),
+            WorkflowOption(
+                "labels_end_col",
+                "string",
+                "Segment end column in separate labels input; intervals are [start, end).",
+                default=None,
+            ),
             WorkflowOption("value_cols", "array", "Comma-separated value columns.", default=["x", "y", "z"]),
             WorkflowOption("window_sizes", "array", "Candidate window sizes.", default=[32, 64, 96, 128, 160]),
             WorkflowOption(
@@ -618,6 +644,13 @@ _WORKFLOWS = {
                 choices=["auto", "minirocket", "rocket", "knn"],
             ),
             WorkflowOption(
+                "labeling",
+                "string",
+                "Window labeling strategy.",
+                default="strict",
+                choices=["strict", "majority"],
+            ),
+            WorkflowOption(
                 "balance",
                 "string",
                 "Window balancing strategy.",
@@ -625,6 +658,8 @@ _WORKFLOWS = {
                 choices=["none", "undersample", "segment_cap"],
             ),
             WorkflowOption("max_windows_per_segment", "integer", "Cap windows per segment when balance=segment_cap.", default=25),
+            WorkflowOption("stride", "integer", "Window stride; defaults to window_size // 2.", default=None),
+            WorkflowOption("n_splits", "integer", "Number of grouped splits for selection and evaluation.", default=3),
             WorkflowOption("test_size", "number", "Test fraction per split.", default=0.25),
             WorkflowOption("seed", "integer", "Random seed for selection and evaluation.", default=1337),
             WorkflowOption("skip_plots", "boolean", "Skip plot generation.", default=False),
@@ -665,7 +700,7 @@ _WORKFLOWS = {
                 },
                 {
                     "type": "tabular",
-                    "description": "CSV/parquet/JSON data with feature columns and a label column.",
+                    "description": "CSV/parquet/JSON data with feature columns and a label column, optionally paired with a separate labels/segments table.",
                 },
             ]
         },
@@ -673,10 +708,12 @@ _WORKFLOWS = {
         examples=[
             "ts-agents workflow show activity-recognition --json",
             "ts-agents workflow run activity-recognition --input data/demo_labeled_stream.csv --label-col label --value-cols x,y,z",
+            "ts-agents workflow run activity-recognition --input signals.csv --time-col ts --value-cols x,y,z --labels-input segments.csv --labels-start-col start --labels-end-col end --label-col activity",
         ],
         capabilities={
             "supported_metrics": ["accuracy", "balanced_accuracy", "f1_macro"],
             "supported_classifiers": ["auto", "minirocket", "rocket", "knn"],
+            "supported_labeling": ["strict", "majority"],
             "supported_balance_strategies": ["none", "undersample", "segment_cap"],
         },
         availability_fn=_activity_workflow_availability,

--- a/ts_agents/workflows/activity.py
+++ b/ts_agents/workflows/activity.py
@@ -20,6 +20,7 @@ from .common import (
 
 _SUPPORTED_CLASSIFIERS = {"auto", "minirocket", "rocket", "knn"}
 _SUPPORTED_METRICS = {"accuracy", "balanced_accuracy", "f1_macro"}
+_SUPPORTED_LABELING = {"strict", "majority"}
 _SUPPORTED_BALANCE = {"none", "undersample", "segment_cap"}
 
 
@@ -30,8 +31,11 @@ def run_activity_recognition_workflow(
     window_sizes: Optional[Iterable[int]] = None,
     metric: str = "balanced_accuracy",
     classifier: str = "auto",
+    labeling: str = "strict",
     balance: str = "segment_cap",
     max_windows_per_segment: int = 25,
+    stride: Optional[int] = None,
+    n_splits: int = 3,
     test_size: float = 0.25,
     seed: int = 1337,
     skip_plots: bool = False,
@@ -46,8 +50,11 @@ def run_activity_recognition_workflow(
     output_path = ensure_output_dir(output_dir)
     selected_classifier = _normalize_classifier(classifier)
     selected_metric = _normalize_metric(metric)
+    selected_labeling = _normalize_labeling(labeling)
     selected_balance = _normalize_balance(balance)
     candidate_windows = _normalize_window_sizes(window_sizes)
+    preparation = (stream_input.provenance.get("stream_ref") or {}).get("preparation")
+    label_source = (stream_input.provenance.get("stream_ref") or {}).get("label_source")
 
     selection = select_window_size(
         stream_input.values,
@@ -55,8 +62,11 @@ def run_activity_recognition_workflow(
         window_sizes=candidate_windows,
         metric=selected_metric,
         classifier=selected_classifier,
+        stride=stride,
+        labeling=selected_labeling,
         balance=selected_balance,
         max_windows_per_segment=max_windows_per_segment,
+        n_splits=n_splits,
         test_size=test_size,
         seed=seed,
     )
@@ -66,8 +76,11 @@ def run_activity_recognition_workflow(
         window_size=int(selection.best_window_size),
         metric=selected_metric,
         classifier=selected_classifier,
+        labeling=selected_labeling,
         balance=selected_balance,
         max_windows_per_segment=max_windows_per_segment,
+        stride=stride,
+        n_splits=n_splits,
         test_size=test_size,
         seed=seed,
     )
@@ -95,10 +108,15 @@ def run_activity_recognition_workflow(
         "classification_method": classification_method,
         "classifier_used": effective_backend,
         "metric": selected_metric,
+        "labeling": selected_labeling,
         "balance": selected_balance,
+        "stride_requested": stride,
+        "n_splits": int(n_splits),
         "seed": int(seed),
         "best_window_size": int(selection.best_window_size),
         "score": float(score) if isinstance(score, (int, float)) else None,
+        "preparation": preparation,
+        "label_source": label_source,
         "quality_flags": quality_flags,
         "window_selection": selection_payload,
         "evaluation": evaluation_payload,
@@ -157,6 +175,12 @@ def run_activity_recognition_workflow(
         classifier_resolved=selected_classifier,
         effective_backend=effective_backend,
         metric=selected_metric,
+        labeling=selected_labeling,
+        balance=selected_balance,
+        stride=stride,
+        n_splits=n_splits,
+        quality_flags=quality_flags,
+        warnings=warnings,
         selection_payload=selection_payload,
         evaluation_payload=evaluation_payload,
     )
@@ -194,8 +218,11 @@ def run_activity_recognition_workflow(
             "window_sizes": candidate_windows,
             "metric": selected_metric,
             "classifier": classifier,
+            "labeling": selected_labeling,
             "balance": selected_balance,
             "max_windows_per_segment": max_windows_per_segment,
+            "stride": stride,
+            "n_splits": n_splits,
             "test_size": test_size,
             "seed": seed,
             "skip_plots": skip_plots,
@@ -219,6 +246,15 @@ def _normalize_metric(raw: str) -> str:
     if normalized not in _SUPPORTED_METRICS:
         raise ValueError(
             f"Unsupported metric '{raw}'. Supported: {', '.join(sorted(_SUPPORTED_METRICS))}."
+        )
+    return normalized
+
+
+def _normalize_labeling(raw: str) -> str:
+    normalized = raw.strip().lower()
+    if normalized not in _SUPPORTED_LABELING:
+        raise ValueError(
+            f"Unsupported labeling strategy '{raw}'. Supported: {', '.join(sorted(_SUPPORTED_LABELING))}."
         )
     return normalized
 
@@ -258,6 +294,28 @@ def _activity_quality_flags(
     n_windows_by_window = selection_payload.get("n_windows_by_window") or {}
     if any(isinstance(count, int) and count < 10 for count in n_windows_by_window.values()):
         flags.append("too_few_windows")
+
+    best_window = selection_payload.get("best_window_size")
+    best_window_diagnostics = _window_diagnostic_for(
+        selection_payload,
+        best_window,
+    )
+    dropped_in_best_window = best_window_diagnostics.get("dropped_classes") or []
+    if dropped_in_best_window:
+        flags.append("best_window_dropped_classes")
+
+    dropped_in_evaluation = evaluation_payload.get("dropped_classes") or []
+    if dropped_in_evaluation:
+        flags.append("evaluation_dropped_classes")
+
+    selection_requested_splits = ((selection_payload.get("details") or {}).get("n_splits"))
+    evaluation_valid_splits = evaluation_payload.get("n_splits")
+    if (
+        isinstance(selection_requested_splits, int)
+        and isinstance(evaluation_valid_splits, int)
+        and evaluation_valid_splits < selection_requested_splits
+    ):
+        flags.append("fewer_valid_splits_than_requested")
 
     classification = evaluation_payload.get("classification") or {}
     confusion = classification.get("confusion_matrix")
@@ -380,38 +438,103 @@ def _build_report(
     classifier_resolved: str,
     effective_backend: str,
     metric: str,
+    labeling: str,
+    balance: str,
+    stride: Optional[int],
+    n_splits: int,
+    quality_flags: list[str],
+    warnings: list[str],
     selection_payload: dict[str, Any],
     evaluation_payload: dict[str, Any],
 ) -> str:
     classification = evaluation_payload.get("classification") or {}
-    note = _build_quality_note(evaluation_payload)
-    return "\n".join(
-        [
-            "### Report on Activity-Recognition Workflow",
-            "",
-            f"- **Source**: `{stream_input.label}`",
-            f"- **Value Columns**: {', '.join(stream_input.value_columns)}",
-            f"- **Label Column**: `{stream_input.label_column}`",
-            f"- **Classifier Requested**: `{classifier_requested}`",
-            f"- **Classifier Resolved**: `{classifier_resolved}`",
-            f"- **Effective Backend**: `{effective_backend}`",
-            f"- **Best Window Size**: {selection_payload.get('best_window_size')}",
-            f"- **Metric**: `{metric}` = {_format_metric(evaluation_payload.get('score'))}",
-            f"- **Accuracy**: {_format_metric(classification.get('accuracy'))}",
-            f"- **Macro F1**: {_format_metric(classification.get('f1_score'))}",
-            "",
-            "#### Note",
-            note,
-        ]
+    retained_classes = _format_label_list(evaluation_payload.get("retained_classes") or [])
+    dropped_classes = _format_label_list(evaluation_payload.get("dropped_classes") or [])
+    flag_text = ", ".join(quality_flags) if quality_flags else "none"
+    warning_text = "; ".join(warnings) if warnings else "none"
+    note = _build_quality_note(
+        selection_payload=selection_payload,
+        evaluation_payload=evaluation_payload,
+        quality_flags=quality_flags,
+        warnings=warnings,
     )
+    sections = [
+        "### Report on Activity-Recognition Workflow",
+        "",
+        "#### Inputs",
+        f"- **Source**: `{stream_input.label}`",
+        f"- **Value Columns**: {', '.join(stream_input.value_columns)}",
+        f"- **Label Column**: `{stream_input.label_column}`",
+        f"- **Preparation**: {_describe_preparation(stream_input)}",
+        "",
+        "#### Controls",
+        f"- **Classifier Requested**: `{classifier_requested}`",
+        f"- **Classifier Resolved**: `{classifier_resolved}`",
+        f"- **Effective Backend**: `{effective_backend}`",
+        f"- **Metric**: `{metric}`",
+        f"- **Labeling**: `{labeling}`",
+        f"- **Balance**: `{balance}`",
+        f"- **Stride**: {stride if stride is not None else 'auto (window_size // 2)' }",
+        f"- **Grouped Splits**: {n_splits}",
+        "",
+        "#### Results",
+        f"- **Best Window Size**: {selection_payload.get('best_window_size')}",
+        f"- **Workflow Score**: {_format_metric(evaluation_payload.get('score'))}",
+        f"- **Accuracy**: {_format_metric(classification.get('accuracy'))}",
+        f"- **Macro F1**: {_format_metric(classification.get('f1_score'))}",
+        f"- **Retained Classes**: {retained_classes}",
+        f"- **Dropped Classes**: {dropped_classes}",
+        f"- **Quality Flags**: {flag_text}",
+        f"- **Warnings**: {warning_text}",
+        "",
+        "#### Window Sweep",
+        _build_window_sweep_table(selection_payload),
+        "",
+        "#### Note",
+        note,
+    ]
+    return "\n".join(sections)
 
 
-def _build_quality_note(evaluation_payload: dict[str, Any]) -> str:
+def _build_quality_note(
+    *,
+    selection_payload: dict[str, Any],
+    evaluation_payload: dict[str, Any],
+    quality_flags: list[str],
+    warnings: list[str],
+) -> str:
+    notes: List[str] = []
+    if warnings:
+        notes.append("Warnings were emitted during artifact generation.")
+
+    best_window = selection_payload.get("best_window_size")
+    best_window_diagnostics = _window_diagnostic_for(selection_payload, best_window)
+    best_window_dropped = best_window_diagnostics.get("dropped_classes") or []
+    if best_window_dropped:
+        notes.append(
+            "Best-scoring window drops class coverage "
+            f"({', '.join(str(label) for label in best_window_dropped)})."
+        )
+
+    dropped_classes = evaluation_payload.get("dropped_classes") or []
+    if dropped_classes:
+        notes.append(
+            "Final evaluation excludes one or more classes "
+            f"({', '.join(str(label) for label in dropped_classes)})."
+        )
+
+    if "fewer_valid_splits_than_requested" in quality_flags:
+        requested = (selection_payload.get("details") or {}).get("n_splits")
+        observed = evaluation_payload.get("n_splits")
+        notes.append(
+            f"Requested {requested} grouped split(s), but only {observed} valid evaluation split(s) were available."
+        )
+
     classification = evaluation_payload.get("classification") or {}
     confusion = classification.get("confusion_matrix")
     active_rows = _count_active_confusion_rows(confusion)
     if active_rows is not None and active_rows <= 1:
-        return "Test split appears single-class; treat classifier metrics with caution."
+        notes.append("Test split appears single-class; treat classifier metrics with caution.")
 
     score = evaluation_payload.get("score")
     accuracy = classification.get("accuracy")
@@ -420,9 +543,89 @@ def _build_quality_note(evaluation_payload: dict[str, Any]) -> str:
         isinstance(value, (int, float)) and float(value) == 1.0
         for value in (score, accuracy, f1_macro)
     ):
-        return "All reported metrics are perfect; verify split balance and leakage assumptions."
+        notes.append("All reported metrics are perfect; verify split balance and leakage assumptions.")
 
+    if notes:
+        return " ".join(notes)
     return "No obvious pathologies detected in the reported classification metrics."
+
+
+def _describe_preparation(stream_input: LabeledStreamInput) -> str:
+    stream_ref = stream_input.provenance.get("stream_ref") or {}
+    preparation = stream_ref.get("preparation") or {}
+    label_source = stream_ref.get("label_source") or {}
+    mode = preparation.get("mode")
+    label_path = label_source.get("path") or label_source.get("label")
+
+    if not mode:
+        return "Used labels already present in the primary input table."
+    if mode == "row_aligned_labels":
+        return f"Merged labels from `{label_path}` by row alignment."
+    if mode == "time_joined_labels":
+        return (
+            f"Merged labels from `{label_path}` on `{preparation.get('signal_time_column')}` "
+            f"using labels column `{preparation.get('labels_time_column')}`."
+        )
+    if mode in {"segment_time_labels", "segment_index_labels"}:
+        basis = (
+            f"time column `{preparation.get('signal_time_column')}`"
+            if preparation.get("signal_time_column")
+            else "row offsets"
+        )
+        return (
+            f"Expanded segment labels from `{label_path}` using {basis}; "
+            "intervals are start-inclusive and end-exclusive."
+        )
+    return "Prepared labels from a separate labels input."
+
+
+def _build_window_sweep_table(selection_payload: dict[str, Any]) -> str:
+    window_diagnostics = (selection_payload.get("details") or {}).get("window_diagnostics") or {}
+    if not window_diagnostics:
+        return "_Window sweep diagnostics were not recorded._"
+
+    lines = [
+        "| Window | Score | Windows | Retained | Dropped | Splits |",
+        "| --- | --- | --- | --- | --- | --- |",
+    ]
+    scores = selection_payload.get("scores_by_window") or {}
+    for window, diagnostic in _sorted_window_diagnostics(window_diagnostics):
+        score = scores.get(window)
+        if score is None and str(window) in scores:
+            score = scores[str(window)]
+        lines.append(
+            "| "
+            f"{window} | {_format_metric(score)} | {diagnostic.get('n_windows', 'n/a')} | "
+            f"{_format_label_list(diagnostic.get('retained_classes') or [])} | "
+            f"{_format_label_list(diagnostic.get('dropped_classes') or [])} | "
+            f"{diagnostic.get('valid_split_count', 0)} |"
+        )
+    return "\n".join(lines)
+
+
+def _sorted_window_diagnostics(window_diagnostics: dict[Any, Any]) -> list[tuple[int, dict[str, Any]]]:
+    items: list[tuple[int, dict[str, Any]]] = []
+    for key, value in window_diagnostics.items():
+        try:
+            window = int(key)
+        except (TypeError, ValueError):
+            continue
+        if isinstance(value, dict):
+            items.append((window, value))
+    return sorted(items, key=lambda item: item[0])
+
+
+def _window_diagnostic_for(selection_payload: dict[str, Any], window_size: Any) -> dict[str, Any]:
+    if window_size is None:
+        return {}
+    window_diagnostics = (selection_payload.get("details") or {}).get("window_diagnostics") or {}
+    return window_diagnostics.get(window_size) or window_diagnostics.get(str(window_size)) or {}
+
+
+def _format_label_list(labels: list[Any]) -> str:
+    if not labels:
+        return "none"
+    return ", ".join(f"`{label}`" for label in labels)
 
 
 def _format_metric(value: Any) -> str:

--- a/ts_agents/workflows/activity.py
+++ b/ts_agents/workflows/activity.py
@@ -91,10 +91,18 @@ def run_activity_recognition_workflow(
     evaluation_classifier = evaluation_payload.get("classifier")
     classification_method = classification.get("method")
     effective_backend = classification_method or evaluation_classifier or selected_classifier
+    warnings: List[str] = []
+    for warning in classification.get("warnings") or []:
+        warning_text = str(warning)
+        if warning_text not in warnings:
+            warnings.append(warning_text)
+
     quality_flags = _activity_quality_flags(
         selection_payload=selection_payload,
         evaluation_payload=evaluation_payload,
     )
+    if warnings and "classifier_backend_warning" not in quality_flags:
+        quality_flags.append("classifier_backend_warning")
     score = evaluation_payload.get("score")
     summary_data = {
         "workflow": workflow_name,
@@ -137,7 +145,6 @@ def run_activity_recognition_workflow(
             created_by=workflow_name,
         ),
     ]
-    warnings: List[str] = []
 
     if not skip_plots:
         selection_fig = None


### PR DESCRIPTION
## Summary

This PR makes activity recognition handle real-world labeled-stream preparation more directly and exposes the windowing controls that materially affect label retention and evaluation validity.

It also tightens the reporting and fallback behavior so degraded runs are visible earlier and backend failures do not abort the workflow unnecessarily.

Closes #85.

## What Changed

- added native activity input preparation for separate signal tables plus separate row-aligned, time-aligned, or segment-label tables
- exposed `labeling`, `stride`, and `n_splits` on the `activity-recognition` workflow CLI and workflow metadata
- aligned final evaluation with the workflow's selection controls and added retention/split diagnostics to selection and evaluation payloads
- upgraded the activity workflow report to include preparation assumptions, retained and dropped classes, quality flags, warnings, and the full window sweep
- switched the legacy `select_window_size_from_csv` and `evaluate_windowed_classifier_from_csv` helpers to reuse the richer labeled-stream loader
- hardened ROCKET and KNN fallback behavior when `aeon` is installed but broken at import or runtime
- updated the mirrored activity-recognition skill docs to describe the new preparation path and controls

## Why

The root issue was that the workflow assumed labels were already present in the final per-timepoint table, while the CLI hid several core knobs that strongly affect class retention and evaluation comparability.

That made normal datasets awkward to prepare, made the CLI thinner than the core API, and allowed reports to look healthier than the underlying retention and split quality warranted.

## Impact

Users can now run activity recognition directly from a signals file plus a separate labels or segments file, tune `strict` vs `majority` labeling and stride/split behavior from the workflow CLI, and see when the selected window drops class coverage or fewer valid grouped splits were available than requested.

## Validation

- `uv run python -m pytest -q tests/cli/test_input_parsing.py tests/core/test_windowing.py tests/core/test_classification.py tests/cli/test_params.py tests/cli/test_demo.py tests/cli/test_workflows.py::test_workflow_run_activity_recognition_writes_expected_files tests/cli/test_workflows.py::test_workflow_run_activity_recognition_surfaces_effective_backend_provenance tests/cli/test_workflows.py::test_workflow_run_activity_recognition_sanitizes_nan_scores_and_surfaces_quality_flags tests/cli/test_workflows.py::test_workflow_run_activity_recognition_continues_when_plot_generation_fails tests/cli/test_workflows.py::test_workflow_run_activity_recognition_threads_new_windowing_controls tests/cli/test_workflows.py::test_workflow_run_activity_recognition_report_surfaces_retention_drops`
- result: 86 passed
