### PR TITLE
Fix Modal sandbox: drop source-checkout guard inside remote run_tool

### DIFF
--- a/ts_agents/sandbox/modal_app.py
+++ b/ts_agents/sandbox/modal_app.py
@@ -67,7 +67,9 @@ image = _build_image()
 @app.function(image=image, timeout=600)
 def run_tool(request: Dict[str, Any]) -> Dict[str, Any]:
     """Execute a tool request and return an ExecutionResult dict."""
-    _require_source_checkout()
+    # Note: the source-checkout precondition applies to image build / local
+    # invocations (see `main`). Inside the remote container only `ts_agents/`
+    # is shipped, so checking for pyproject.toml here would always fail.
 
     # Import inside the function to ensure the packaged code is available.
     from ts_agents.sandbox.runner import run_request


### PR DESCRIPTION
## Summary
- `ts_agents/sandbox/modal_app.py` was calling `_require_source_checkout()` *inside* the remote `run_tool` Modal function. The Modal image only ships the `ts_agents/` package (via `add_local_python_source`), not `pyproject.toml`, so the check always raised `RuntimeError("...must be executed from a source checkout...")` and every remote invocation failed.
- Removed the call from `run_tool` and added a short comment explaining where the precondition still applies (image build and local entrypoint).

Regression introduced in 1b0be1d ("Address P1 PR review comments"). Caught by running the smoke test from `SANDBOX.md`:

```
[modal] execution error: RuntimeError('ts_agents.sandbox.modal_app must be executed from a source checkout that contains pyproject.toml and the ts_agents package tree.')
```

After the fix, `uv run ts-agents tool run describe_series --input-json '{"series":[1,2,3,4,5,6,7,8,9,10]}' --sandbox modal` returns the expected `describe_series` output.

## Test plan
- [x] Manual: deploy + invoke `describe_series` end-to-end (`modal deploy -m ts_agents.sandbox.modal_app --env main --name ts-agents-sandbox`, then `--sandbox modal` smoke test) — passes locally
- [x] CI checks
- [x] Reviewer: consider whether the Daytona path needs a similar audit, and whether a regression test should mock the Modal SDK to assert `run_tool` doesn't depend on `pyproject.toml`

## Note for redeployment
`modal deploy` reuses cached source mounts; after editing `modal_app.py` you may need `modal app stop ts-agents-sandbox --env main --yes` before redeploying to see source changes take effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)