### PR TITLE
Add constrained autoresearch loops

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,12 @@ It ships with three first-class workflows:
 - `forecast-series` (baseline comparison + forecast/report artifacts)
 - `activity-recognition` (labeled-stream window-size selection + evaluation)
 
+It also includes autoresearch loops for repeatable dataset/model/metric
+experiments:
+- `forecast-daytona` (M4 mini forecasting baselines under constrained resources)
+- `classify-daytona` (windowed activity classification under constrained resources)
+- `foundation-gpu-plan` (plan-only Chronos/MOMENT GPU fine-tuning recipes)
+
 Legacy compatibility aliases for `ts-agents demo ...` remain available for one
 release cycle and emit deprecation warnings.
 
@@ -69,7 +75,28 @@ ARIMA/ETS/Theta forecasting and `activity-recognition`. From a source
 checkout, plain `uv sync` matches the base CLI-first install; use
 `uv sync --extra recommended` for the same recommended workflow stack.
 
-### 2. Use the low-level CLI on bundled or custom data
+### 2. Run autoresearch loops
+
+Use autoresearch loops when you want a bounded comparison plan with datasets,
+models, metrics, budgets, and artifacts chosen up front. The Daytona-oriented
+statistical/classical loops are benchmark-style searches: `--max-trials` counts
+model/evaluation-spec rows. They default to vendored or generated datasets and
+fit 4 vCPU / 8 GiB RAM / 10 GiB disk sandboxes.
+
+```bash
+ts-agents autoresearch list --json
+ts-agents autoresearch show forecast-daytona --json
+ts-agents autoresearch run forecast-daytona --profile smoke --models seasonal_naive --json
+ts-agents autoresearch run classify-daytona --profile smoke --dataset synthetic --models knn --json
+ts-agents autoresearch run foundation-gpu-plan --json
+```
+
+Pass `--sandbox daytona` to run an autoresearch loop through the Daytona
+backend after configuring `DAYTONA_API_KEY`; use `--dry-run` to materialize the
+trial plan without fitting models. `foundation-gpu-plan` is intentionally
+plan-only and reports no trained-model metrics.
+
+### 3. Use the low-level CLI on bundled or custom data
 
 Use the low-level tool registry when you want direct access to individual
 analysis functions.
@@ -82,7 +109,7 @@ ts-agents sandbox list
 ts-agents skills show forecasting
 ```
 
-### 3. Launch the UI or prepare a hosted demo
+### 4. Launch the UI or prepare a hosted demo
 
 Use the Gradio app for interactive exploration, or the hosted entrypoint for a
 manual/public demo deployment. This is optional and secondary to the CLI.
@@ -177,7 +204,7 @@ ts-agents workflow run inspect-series \
 ```
 
 `sandbox doctor` probes readiness (including Docker image presence). Docker,
-Daytona, and Modal all stage workflow artifacts back to the host output
+Daytona, and Modal all stage workflow and autoresearch artifacts back to the host output
 directory so `result.artifacts[*].path` and `result.data.output_dir` are
 always host-accessible. Fallback is explicit — the executor refuses to silently
 switch backends unless `--allow-fallback` is passed.

--- a/SANDBOX.md
+++ b/SANDBOX.md
@@ -44,6 +44,7 @@ uv run ts-agents tool run describe_series --input-json '{"series":[1,2,3,4]}' --
 | `DAYTONA_API_URL` | Daytona API endpoint override | Daytona default |
 | `DAYTONA_TARGET` | Daytona target/region override | Daytona org default |
 | `TS_AGENTS_DAYTONA_SNAPSHOT` | Daytona snapshot override | `daytonaio/sandbox:0.4.3` |
+| `TS_AGENTS_DAYTONA_REPO_BRANCH` | Git branch cloned during Daytona bootstrap | default branch |
 | `TS_AGENTS_DAYTONA_TIMEOUT` | Timeout for Daytona commands | `300` |
 | `TS_AGENTS_DAYTONA_STREAM` | Stream Daytona bootstrap/runner logs to stderr | `true` |
 | `TS_AGENTS_DAYTONA_LOG_FILE` | Append Daytona streamed logs to file | _(none)_ |
@@ -55,6 +56,8 @@ uv run ts-agents tool run describe_series --input-json '{"series":[1,2,3,4]}' --
 | `TS_AGENTS_MODAL_STREAM` | Stream `modal app logs` while remote call runs | `true` |
 | `TS_AGENTS_MODAL_LOG_FILE` | Append Modal stream logs to file | _(none)_ |
 | `TS_AGENTS_MODAL_LOG_TIMESTAMPS` | Include timestamps in Modal log stream | `false` |
+| `TS_AGENTS_AUTORESEARCH_ARTIFACT_MAX_FILE_BYTES` | Max single autoresearch artifact staged back from remote sandboxes; non-positive disables | `16777216` |
+| `TS_AGENTS_AUTORESEARCH_ARTIFACT_MAX_TOTAL_BYTES` | Max total autoresearch artifact bytes staged back from remote sandboxes; non-positive disables | `67108864` |
 
 ## Docker sandbox
 
@@ -93,6 +96,8 @@ export DAYTONA_API_KEY=your_daytona_api_key
 # export DAYTONA_TARGET=...
 # Optional snapshot override:
 # export TS_AGENTS_DAYTONA_SNAPSHOT=daytonaio/sandbox:0.4.3
+# Optional branch override for testing an unmerged branch:
+# export TS_AGENTS_DAYTONA_REPO_BRANCH=issue-90-autoresearch-loops
 # Optional: stream bootstrap/runner logs to stderr (default=true)
 # export TS_AGENTS_DAYTONA_STREAM=true
 # Optional: persist streamed Daytona logs to a local file
@@ -104,8 +109,28 @@ export TS_AGENTS_SANDBOX_MODE=daytona
 `https://github.com/fnauman/ts-agents` into `workspace/ts-agents` and running
 `pip install -e` there before tool execution. The default snapshot is
 `daytonaio/sandbox:0.4.3`; override with `TS_AGENTS_DAYTONA_SNAPSHOT` if needed.
+Before this branch is merged to the repository default branch, set
+`TS_AGENTS_DAYTONA_REPO_BRANCH=issue-90-autoresearch-loops` so Daytona clones
+this implementation rather than `main`.
 
-Then run any `ts-agents tool run ... --sandbox daytona` command.
+Then run any `ts-agents tool run ... --sandbox daytona`, `ts-agents workflow run ... --sandbox daytona`, or `ts-agents autoresearch run ... --sandbox daytona` command.
+
+Daytona-oriented autoresearch smoke examples (`--max-trials` counts model/evaluation-spec rows):
+
+```bash
+uv run ts-agents autoresearch run forecast-daytona \
+  --profile smoke \
+  --models seasonal_naive \
+  --sandbox daytona \
+  --json
+
+uv run ts-agents autoresearch run classify-daytona \
+  --profile smoke \
+  --dataset synthetic \
+  --models knn \
+  --sandbox daytona \
+  --json
+```
 
 ## Modal
 

--- a/SANDBOX.md
+++ b/SANDBOX.md
@@ -97,7 +97,7 @@ export DAYTONA_API_KEY=your_daytona_api_key
 # Optional snapshot override:
 # export TS_AGENTS_DAYTONA_SNAPSHOT=daytonaio/sandbox:0.4.3
 # Optional branch override for testing an unmerged branch:
-# export TS_AGENTS_DAYTONA_REPO_BRANCH=issue-90-autoresearch-loops
+# export TS_AGENTS_DAYTONA_REPO_BRANCH=my-feature-branch
 # Optional: stream bootstrap/runner logs to stderr (default=true)
 # export TS_AGENTS_DAYTONA_STREAM=true
 # Optional: persist streamed Daytona logs to a local file
@@ -109,10 +109,6 @@ export TS_AGENTS_SANDBOX_MODE=daytona
 `https://github.com/fnauman/ts-agents` into `workspace/ts-agents` and running
 `pip install -e` there before tool execution. The default snapshot is
 `daytonaio/sandbox:0.4.3`; override with `TS_AGENTS_DAYTONA_SNAPSHOT` if needed.
-Before this branch is merged to the repository default branch, set
-`TS_AGENTS_DAYTONA_REPO_BRANCH=issue-90-autoresearch-loops` so Daytona clones
-this implementation rather than `main`.
-
 Then run any `ts-agents tool run ... --sandbox daytona`, `ts-agents workflow run ... --sandbox daytona`, or `ts-agents autoresearch run ... --sandbox daytona` command.
 
 Daytona-oriented autoresearch smoke examples (`--max-trials` counts model/evaluation-spec rows):

--- a/tests/cli/test_autoresearch.py
+++ b/tests/cli/test_autoresearch.py
@@ -32,6 +32,30 @@ def test_autoresearch_show_json_returns_budget(capsys):
     assert "seasonal_naive" in result["models"]
 
 
+def test_autoresearch_run_rejects_zero_max_trials(capsys, tmp_path):
+    code = run(
+        [
+            "autoresearch",
+            "run",
+            "forecast-daytona",
+            "--profile",
+            "smoke",
+            "--models",
+            "seasonal_naive",
+            "--max-trials",
+            "0",
+            "--output-dir",
+            str(tmp_path / "forecast-zero"),
+            "--json",
+        ]
+    )
+
+    assert code == 2
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["ok"] is False
+    assert "--max-trials must be a positive integer" in payload["error"]["message"]
+
+
 def test_autoresearch_run_forecast_smoke_writes_artifacts(capsys, tmp_path):
     output_dir = tmp_path / "forecast"
     code = run(
@@ -71,6 +95,34 @@ def test_autoresearch_run_forecast_smoke_writes_artifacts(capsys, tmp_path):
     assert manifest["best_config"]["model"] == "seasonal_naive"
     assert manifest["best_config"]["n_trials"] == 2
     assert manifest["options"]["max_trials"] == 2
+
+
+def test_autoresearch_manifest_includes_plot_artifact(capsys, tmp_path):
+    output_dir = tmp_path / "forecast-plot"
+    code = run(
+        [
+            "autoresearch",
+            "run",
+            "forecast-daytona",
+            "--profile",
+            "smoke",
+            "--models",
+            "seasonal_naive",
+            "--max-trials",
+            "1",
+            "--output-dir",
+            str(output_dir),
+            "--json",
+        ]
+    )
+
+    assert code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["ok"] is True
+    assert (output_dir / "ranking.png").exists()
+    manifest = json.loads((output_dir / "run_manifest.json").read_text())
+    manifest_paths = {artifact["path"] for artifact in manifest["artifacts"]}
+    assert str(output_dir / "ranking.png") in manifest_paths
 
 
 def test_autoresearch_run_classification_dry_run(capsys, tmp_path):
@@ -208,3 +260,42 @@ def test_autoresearch_serialized_runner_honors_artifact_dir_env(monkeypatch, tmp
 
     assert result["data"]["output_dir"] == str(artifact_root / "forecast-daytona")
     assert (artifact_root / "forecast-daytona" / "run_manifest.json").exists()
+
+
+def test_autoresearch_artifact_limit_falls_back_after_invalid_specific_env(monkeypatch):
+    from ts_agents.autoresearch.executor import _autoresearch_artifact_bundle_limits
+
+    monkeypatch.setenv("TS_AGENTS_AUTORESEARCH_ARTIFACT_MAX_FILE_BYTES", "not-an-int")
+    monkeypatch.setenv("TS_AGENTS_WORKFLOW_ARTIFACT_MAX_FILE_BYTES", "123")
+    monkeypatch.setenv("TS_AGENTS_AUTORESEARCH_ARTIFACT_MAX_TOTAL_BYTES", "also-bad")
+    monkeypatch.setenv("TS_AGENTS_WORKFLOW_ARTIFACT_MAX_TOTAL_BYTES", "456")
+
+    assert _autoresearch_artifact_bundle_limits() == (123, 456)
+
+
+def test_forecast_ranking_puts_nan_metrics_last():
+    from ts_agents.autoresearch.runner import _rank_forecast_trials
+
+    ranking = _rank_forecast_trials(
+        [
+            {
+                "status": "ok",
+                "model": "bad",
+                "phase": "holdout",
+                "smape": float("nan"),
+                "mae": float("nan"),
+                "rmse": float("nan"),
+            },
+            {
+                "status": "ok",
+                "model": "good",
+                "phase": "holdout",
+                "smape": 1.0,
+                "mae": 1.0,
+                "rmse": 1.0,
+            },
+        ]
+    )
+
+    assert [row["model"] for row in ranking] == ["good", "bad"]
+    assert ranking[1]["smape"] is None

--- a/tests/cli/test_autoresearch.py
+++ b/tests/cli/test_autoresearch.py
@@ -1,6 +1,10 @@
 import json
+import os
+import signal
 import subprocess
+import time
 
+import pytest
 import yaml
 
 from ts_agents.cli.main import run
@@ -123,6 +127,7 @@ def test_autoresearch_manifest_includes_plot_artifact(capsys, tmp_path):
     manifest = json.loads((output_dir / "run_manifest.json").read_text())
     manifest_paths = {artifact["path"] for artifact in manifest["artifacts"]}
     assert str(output_dir / "ranking.png") in manifest_paths
+    assert str(output_dir / "run_manifest.json") not in manifest_paths
 
 
 def test_autoresearch_run_classification_dry_run(capsys, tmp_path):
@@ -155,7 +160,9 @@ def test_autoresearch_run_classification_dry_run(capsys, tmp_path):
     assert (output_dir / "trials.csv").exists()
 
 
-def test_autoresearch_run_foundation_gpu_plan_materializes_plan_only_recipes(capsys, tmp_path):
+def test_autoresearch_run_foundation_gpu_plan_materializes_plan_only_recipes(
+    capsys, tmp_path
+):
     output_dir = tmp_path / "foundation"
     code = run(
         [
@@ -175,7 +182,10 @@ def test_autoresearch_run_foundation_gpu_plan_materializes_plan_only_recipes(cap
     assert payload["result"]["status"] == "plan-only"
     assert payload["result"]["data"]["trial_count"] == 0
     assert payload["result"]["data"]["best_config"] == {}
-    assert payload["result"]["data"]["plan"]["target_hardware"] == "1x RTX PRO 6000 Blackwell"
+    assert (
+        payload["result"]["data"]["plan"]["target_hardware"]
+        == "1x RTX PRO 6000 Blackwell"
+    )
     assert payload["result"]["data"]["plan"]["plan_only"] is True
     assert payload["result"]["data"]["plan"]["model_revisions"]["amazon/chronos-2"]
     assert (output_dir / "foundation_gpu_plan.json").exists()
@@ -184,8 +194,12 @@ def test_autoresearch_run_foundation_gpu_plan_materializes_plan_only_recipes(cap
     assert (output_dir / "commands.sh").exists()
 
     subprocess.run(["bash", "-n", str(output_dir / "commands.sh")], check=True)
-    chronos_config = yaml.safe_load((output_dir / "chronos_finetune_config.yaml").read_text())
-    moment_config = yaml.safe_load((output_dir / "moment_classification_config.yaml").read_text())
+    chronos_config = yaml.safe_load(
+        (output_dir / "chronos_finetune_config.yaml").read_text()
+    )
+    moment_config = yaml.safe_load(
+        (output_dir / "moment_classification_config.yaml").read_text()
+    )
     assert chronos_config["adapter_required"] is True
     assert chronos_config["prediction_length"] == 18
     assert chronos_config["training_data_paths"] == []
@@ -299,3 +313,347 @@ def test_forecast_ranking_puts_nan_metrics_last():
 
     assert [row["model"] for row in ranking] == ["good", "bad"]
     assert ranking[1]["smape"] is None
+
+
+def test_autoresearch_preserves_explicit_zero_timeout(capsys, tmp_path):
+    output_dir = tmp_path / "zero-timeout"
+    code = run(
+        [
+            "autoresearch",
+            "run",
+            "forecast-daytona",
+            "--profile",
+            "smoke",
+            "--models",
+            "seasonal_naive",
+            "--max-trials",
+            "1",
+            "--timeout-seconds",
+            "0",
+            "--dry-run",
+            "--skip-plots",
+            "--output-dir",
+            str(output_dir),
+            "--json",
+        ]
+    )
+
+    assert code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["ok"] is True
+    manifest = json.loads((output_dir / "run_manifest.json").read_text())
+    assert manifest["options"]["timeout_seconds"] == 0
+
+
+def test_autoresearch_cli_preserves_explicit_zero_resource_context(
+    monkeypatch, capsys, tmp_path
+):
+    import ts_agents.autoresearch.executor as executor_module
+    from ts_agents.tools.executor import ExecutionResult, ExecutionStatus
+
+    captured = {}
+
+    def fake_execute_autoresearch(_loop_name, _options, *, context):
+        captured["context"] = context
+        return ExecutionResult(
+            status=ExecutionStatus.SUCCESS,
+            result={
+                "kind": "autoresearch",
+                "summary": "ok",
+                "status": "ok",
+                "data": {
+                    "output_dir": str(tmp_path / "out"),
+                    "manifest_path": str(tmp_path / "out" / "run_manifest.json"),
+                    "best_config": {},
+                },
+                "artifacts": [],
+                "warnings": [],
+            },
+        )
+
+    monkeypatch.setattr(
+        executor_module, "execute_autoresearch", fake_execute_autoresearch
+    )
+    code = run(
+        [
+            "autoresearch",
+            "run",
+            "forecast-daytona",
+            "--timeout-seconds",
+            "0",
+            "--memory-mb",
+            "0",
+            "--disk-mb",
+            "0",
+            "--output-dir",
+            str(tmp_path / "out"),
+            "--json",
+        ]
+    )
+
+    assert code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["ok"] is True
+    assert captured["context"].timeout_seconds == 0
+    assert captured["context"].memory_mb == 0
+    assert captured["context"].disk_mb == 0
+
+
+def test_forecast_full_profile_expands_dry_run_trials(capsys, tmp_path):
+    counts = {}
+    for profile in ["default", "full"]:
+        output_dir = tmp_path / profile
+        code = run(
+            [
+                "autoresearch",
+                "run",
+                "forecast-daytona",
+                "--profile",
+                profile,
+                "--models",
+                "seasonal_naive",
+                "--dry-run",
+                "--skip-plots",
+                "--output-dir",
+                str(output_dir),
+                "--json",
+            ]
+        )
+        assert code == 0
+        payload = json.loads(capsys.readouterr().out)
+        counts[profile] = payload["result"]["data"]["trial_count"]
+
+    assert counts["full"] > counts["default"]
+
+
+def test_autoresearch_plot_failure_keeps_manifest(monkeypatch, capsys, tmp_path):
+    from ts_agents.autoresearch import runner
+
+    def raise_plot(_output_path, _trials):
+        raise OSError("read-only output")
+
+    monkeypatch.setattr(runner, "_write_forecast_plot", raise_plot)
+    output_dir = tmp_path / "plot-failure"
+    code = run(
+        [
+            "autoresearch",
+            "run",
+            "forecast-daytona",
+            "--profile",
+            "smoke",
+            "--models",
+            "seasonal_naive",
+            "--max-trials",
+            "1",
+            "--output-dir",
+            str(output_dir),
+            "--json",
+        ]
+    )
+
+    assert code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["quality_status"] == "degraded"
+    assert any(
+        "Skipped ranking plot" in warning for warning in payload["result"]["warnings"]
+    )
+    assert (output_dir / "run_manifest.json").exists()
+    assert (output_dir / "trials.csv").exists()
+
+
+def test_normalize_models_rejects_null_entries():
+    from ts_agents.autoresearch.runner import _normalize_models
+
+    with pytest.raises(ValueError, match="contains a null entry"):
+        _normalize_models("classify-daytona", [None, "knn"])
+
+
+def test_classification_ranking_puts_missing_metric_after_real_zero():
+    from ts_agents.autoresearch.runner import _rank_classification_trials
+
+    ranking = _rank_classification_trials(
+        [
+            {
+                "status": "ok",
+                "model": "missing",
+                "best_window_size": 32,
+                "n_windows": 10,
+            },
+            {
+                "status": "ok",
+                "model": "zero",
+                "balanced_accuracy": 0.0,
+                "best_window_size": 64,
+                "n_windows": 10,
+            },
+        ]
+    )
+
+    assert [row["model"] for row in ranking] == ["zero", "missing"]
+
+
+def test_daytona_extras_context_isolated_between_loops():
+    from ts_agents.autoresearch.executor import _context_with_loop_environment
+    from ts_agents.autoresearch.registry import get_loop
+    from ts_agents.tools.executor import ExecutionContext, SandboxMode
+
+    context = ExecutionContext(
+        sandbox_mode=SandboxMode.DAYTONA,
+        environment={"TS_AGENTS_DAYTONA_INSTALL_EXTRAS": "previous"},
+    )
+    forecast_context = _context_with_loop_environment(
+        context, get_loop("forecast-daytona"), SandboxMode.DAYTONA
+    )
+    classify_context = _context_with_loop_environment(
+        context, get_loop("classify-daytona"), SandboxMode.DAYTONA
+    )
+
+    assert context.environment == {"TS_AGENTS_DAYTONA_INSTALL_EXTRAS": "previous"}
+    assert (
+        forecast_context.environment["TS_AGENTS_DAYTONA_INSTALL_EXTRAS"]
+        == "forecasting"
+    )
+    assert (
+        classify_context.environment["TS_AGENTS_DAYTONA_INSTALL_EXTRAS"]
+        == "classification"
+    )
+
+
+def test_autoresearch_local_dependency_preflight(monkeypatch, tmp_path):
+    import ts_agents.autoresearch.executor as executor_module
+    from ts_agents.autoresearch.executor import AutoresearchExecutor
+    from ts_agents.tools.executor import ExecutionContext, SandboxMode, ToolErrorCode
+
+    def fake_find_spec(name):
+        if name == "statsforecast":
+            return None
+        return object()
+
+    monkeypatch.setattr(executor_module, "find_spec", fake_find_spec)
+    result = AutoresearchExecutor().execute(
+        "forecast-daytona",
+        {
+            "output_dir": str(tmp_path / "deps"),
+            "models": ["theta"],
+        },
+        context=ExecutionContext(sandbox_mode=SandboxMode.LOCAL),
+    )
+
+    assert not result.success
+    assert result.error is not None
+    assert result.error.code == ToolErrorCode.DEPENDENCY_ERROR
+    assert "statsforecast" in result.error.message
+
+
+def test_docker_artifact_materialization_preserves_nested_paths(tmp_path):
+    from ts_agents.autoresearch.executor import _materialize_existing_artifacts
+    from ts_agents.tools.executor import ExecutionResult, ExecutionStatus
+
+    source_root = tmp_path / "sandbox"
+    plot = source_root / "plots" / "ranking.png"
+    data = source_root / "data" / "summary.json"
+    plot.parent.mkdir(parents=True)
+    data.parent.mkdir(parents=True)
+    plot.write_bytes(b"plot")
+    data.write_text("{}")
+    result = ExecutionResult(
+        status=ExecutionStatus.SUCCESS,
+        result={
+            "data": {
+                "output_dir": str(source_root),
+                "manifest_path": str(source_root / "run_manifest.json"),
+            },
+            "artifacts": [
+                {"path": str(plot), "kind": "image"},
+                {"path": str(data), "kind": "json"},
+            ],
+        },
+    )
+    destination = tmp_path / "host"
+
+    _materialize_existing_artifacts(result, str(destination))
+
+    assert (destination / "plots" / "ranking.png").read_bytes() == b"plot"
+    assert (destination / "data" / "summary.json").read_text() == "{}"
+    assert not (destination / "ranking.png").exists()
+
+
+def test_remote_artifact_materialization_rejects_symlink_destination(tmp_path):
+    from ts_agents.autoresearch.executor import (
+        _STAGED_AUTORESEARCH_ARTIFACTS_KEY,
+        _materialize_remote_autoresearch_output,
+    )
+    from ts_agents.tools.executor import ExecutionResult, ExecutionStatus
+
+    if not hasattr(os, "symlink"):
+        pytest.skip("symlink support is required")
+    destination = tmp_path / "host"
+    destination.mkdir()
+    outside = tmp_path / "outside.txt"
+    outside.write_text("keep")
+    try:
+        os.symlink(outside, destination / "evil")
+    except OSError:
+        pytest.skip("symlink creation is not permitted")
+
+    result = ExecutionResult(
+        status=ExecutionStatus.SUCCESS,
+        result={
+            "data": {"manifest_path": "run_manifest.json"},
+            "artifacts": [{"path": "/sandbox/evil", "kind": "text"}],
+            _STAGED_AUTORESEARCH_ARTIFACTS_KEY: [
+                {
+                    "source_path": "/sandbox/evil",
+                    "relative_path": "evil",
+                    "content_base64": "b3ZlcndyaXRl",
+                }
+            ],
+        },
+    )
+
+    _materialize_remote_autoresearch_output(result, str(destination))
+
+    assert outside.read_text() == "keep"
+    assert any(
+        "destination is a symlink" in warning
+        for warning in result.result.get("warnings", [])
+    )
+
+
+def test_docker_artifact_dir_is_run_scoped():
+    from ts_agents.autoresearch.executor import _sandbox_autoresearch_artifact_dir
+    from ts_agents.tools.executor import SandboxMode
+
+    first = _sandbox_autoresearch_artifact_dir(SandboxMode.DOCKER)
+    second = _sandbox_autoresearch_artifact_dir(SandboxMode.DOCKER)
+
+    assert first != second
+    assert first.startswith("/io/artifacts/")
+    assert second.startswith("/io/artifacts/")
+
+
+def test_trial_timeout_restores_expired_outer_alarm_immediately():
+    from ts_agents.autoresearch.runner import _trial_timeout
+
+    if not hasattr(signal, "SIGALRM") or not hasattr(signal, "ITIMER_REAL"):
+        pytest.skip("SIGALRM timers are required")
+
+    class OuterAlarm(Exception):
+        pass
+
+    def raise_outer_alarm(_signum, _frame):
+        raise OuterAlarm
+
+    previous_handler = signal.getsignal(signal.SIGALRM)
+    previous_timer = signal.getitimer(signal.ITIMER_REAL)
+    signal.signal(signal.SIGALRM, raise_outer_alarm)
+    signal.setitimer(signal.ITIMER_REAL, 0.05)
+    try:
+        with pytest.raises(OuterAlarm):
+            with _trial_timeout(1.0):
+                time.sleep(0.1)
+    finally:
+        signal.setitimer(signal.ITIMER_REAL, 0.0)
+        signal.signal(signal.SIGALRM, previous_handler)
+        if previous_timer[0] > 0:
+            signal.setitimer(signal.ITIMER_REAL, previous_timer[0], previous_timer[1])

--- a/tests/cli/test_autoresearch.py
+++ b/tests/cli/test_autoresearch.py
@@ -1,0 +1,210 @@
+import json
+import subprocess
+
+import yaml
+
+from ts_agents.cli.main import run
+
+
+def test_autoresearch_list_json_returns_loops(capsys):
+    code = run(["autoresearch", "list", "--json"])
+
+    assert code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["ok"] is True
+    assert payload["command"] == "autoresearch list"
+    names = [loop["name"] for loop in payload["result"]["loops"]]
+    assert "forecast-daytona" in names
+    assert "classify-daytona" in names
+    assert "foundation-gpu-plan" in names
+
+
+def test_autoresearch_show_json_returns_budget(capsys):
+    code = run(["autoresearch", "show", "forecast-daytona", "--json"])
+
+    assert code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["ok"] is True
+    assert payload["name"] == "forecast-daytona"
+    result = payload["result"]
+    assert result["primary_metric"] == "smape"
+    assert result["budget"]["vcpu"] == 4
+    assert "seasonal_naive" in result["models"]
+
+
+def test_autoresearch_run_forecast_smoke_writes_artifacts(capsys, tmp_path):
+    output_dir = tmp_path / "forecast"
+    code = run(
+        [
+            "autoresearch",
+            "run",
+            "forecast-daytona",
+            "--profile",
+            "smoke",
+            "--models",
+            "seasonal_naive",
+            "--max-trials",
+            "2",
+            "--skip-plots",
+            "--output-dir",
+            str(output_dir),
+            "--json",
+        ]
+    )
+
+    assert code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["ok"] is True
+    assert payload["quality_status"] == "ok"
+    assert payload["execution"]["backend_actual"] == "local"
+    assert payload["result"]["data"]["trial_count"] == 2
+    assert payload["result"]["data"]["best_config"]["model"] == "seasonal_naive"
+    assert payload["result"]["data"]["best_config"]["n_trials"] == 2
+    assert payload["result"]["data"]["best_config"]["n_holdout_trials"] == 1
+    assert payload["result"]["data"]["best_config"]["n_rolling_trials"] == 1
+    assert (output_dir / "trials.csv").exists()
+    assert (output_dir / "trials.jsonl").exists()
+    assert (output_dir / "best_config.json").exists()
+    assert (output_dir / "run_manifest.json").exists()
+    manifest = json.loads((output_dir / "run_manifest.json").read_text())
+    assert manifest["loop"] == "forecast-daytona"
+    assert manifest["best_config"]["model"] == "seasonal_naive"
+    assert manifest["best_config"]["n_trials"] == 2
+    assert manifest["options"]["max_trials"] == 2
+
+
+def test_autoresearch_run_classification_dry_run(capsys, tmp_path):
+    output_dir = tmp_path / "classification"
+    code = run(
+        [
+            "autoresearch",
+            "run",
+            "classify-daytona",
+            "--profile",
+            "smoke",
+            "--models",
+            "knn",
+            "--dataset",
+            "synthetic",
+            "--max-trials",
+            "1",
+            "--dry-run",
+            "--output-dir",
+            str(output_dir),
+            "--json",
+        ]
+    )
+
+    assert code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["ok"] is True
+    assert payload["result"]["data"]["trial_count"] == 1
+    assert (output_dir / "synthetic_labeled_stream.csv").exists()
+    assert (output_dir / "trials.csv").exists()
+
+
+def test_autoresearch_run_foundation_gpu_plan_materializes_plan_only_recipes(capsys, tmp_path):
+    output_dir = tmp_path / "foundation"
+    code = run(
+        [
+            "autoresearch",
+            "run",
+            "foundation-gpu-plan",
+            "--output-dir",
+            str(output_dir),
+            "--json",
+        ]
+    )
+
+    assert code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["ok"] is True
+    assert payload["quality_status"] == "review"
+    assert payload["result"]["status"] == "plan-only"
+    assert payload["result"]["data"]["trial_count"] == 0
+    assert payload["result"]["data"]["best_config"] == {}
+    assert payload["result"]["data"]["plan"]["target_hardware"] == "1x RTX PRO 6000 Blackwell"
+    assert payload["result"]["data"]["plan"]["plan_only"] is True
+    assert payload["result"]["data"]["plan"]["model_revisions"]["amazon/chronos-2"]
+    assert (output_dir / "foundation_gpu_plan.json").exists()
+    assert (output_dir / "chronos_finetune_config.yaml").exists()
+    assert (output_dir / "moment_classification_config.yaml").exists()
+    assert (output_dir / "commands.sh").exists()
+
+    subprocess.run(["bash", "-n", str(output_dir / "commands.sh")], check=True)
+    chronos_config = yaml.safe_load((output_dir / "chronos_finetune_config.yaml").read_text())
+    moment_config = yaml.safe_load((output_dir / "moment_classification_config.yaml").read_text())
+    assert chronos_config["adapter_required"] is True
+    assert chronos_config["prediction_length"] == 18
+    assert chronos_config["training_data_paths"] == []
+    assert moment_config["adapter_required"] is True
+    assert moment_config["dataset_path"] is None
+    assert "training/train.py" not in (output_dir / "commands.sh").read_text()
+
+    manifest = json.loads((output_dir / "run_manifest.json").read_text())
+    assert manifest["loop"] == "foundation-gpu-plan"
+    assert manifest["status"] == "plan-only"
+    assert manifest["best_config"] == {}
+
+
+def test_autoresearch_subprocess_sandbox_hook(capsys, tmp_path):
+    output_dir = tmp_path / "subprocess"
+    code = run(
+        [
+            "autoresearch",
+            "run",
+            "forecast-daytona",
+            "--profile",
+            "smoke",
+            "--models",
+            "seasonal_naive",
+            "--max-trials",
+            "1",
+            "--dry-run",
+            "--output-dir",
+            str(output_dir),
+            "--sandbox",
+            "subprocess",
+            "--json",
+        ]
+    )
+
+    assert code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["ok"] is True
+    assert payload["execution"]["backend_actual"] == "subprocess"
+    assert payload["result"]["data"]["output_dir"] == str(output_dir)
+
+
+def test_autoresearch_unknown_loop_json_error(capsys):
+    code = run(["autoresearch", "show", "not-a-loop", "--json"])
+
+    assert code == 2
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["ok"] is False
+    assert payload["command"] == "autoresearch show"
+    assert payload["name"] == "not-a-loop"
+    assert payload["error"]["code"] == "validation_error"
+    assert "Unknown autoresearch loop" in payload["error"]["message"]
+
+
+def test_autoresearch_serialized_runner_honors_artifact_dir_env(monkeypatch, tmp_path):
+    from ts_agents.autoresearch.executor import _run_serialized_autoresearch
+
+    artifact_root = tmp_path / "artifacts"
+    monkeypatch.setenv("TS_AGENTS_TOOL_ARTIFACT_DIR", str(artifact_root))
+
+    result = _run_serialized_autoresearch(
+        loop_name="forecast-daytona",
+        options={
+            "profile": "smoke",
+            "models": ["seasonal_naive"],
+            "max_trials": 1,
+            "dry_run": True,
+            "skip_plots": True,
+        },
+        use_sandbox_artifact_dir=True,
+    )
+
+    assert result["data"]["output_dir"] == str(artifact_root / "forecast-daytona")
+    assert (artifact_root / "forecast-daytona" / "run_manifest.json").exists()

--- a/ts_agents/autoresearch/__init__.py
+++ b/ts_agents/autoresearch/__init__.py
@@ -1,0 +1,11 @@
+"""Autoresearch loop definitions and runners."""
+
+from .registry import get_loop, list_loops, loop_to_dict
+from .runner import run_autoresearch_loop
+
+__all__ = [
+    "get_loop",
+    "list_loops",
+    "loop_to_dict",
+    "run_autoresearch_loop",
+]

--- a/ts_agents/autoresearch/executor.py
+++ b/ts_agents/autoresearch/executor.py
@@ -1,0 +1,489 @@
+"""Sandbox-aware execution for autoresearch loops."""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import os
+from pathlib import Path
+import shutil
+import tempfile
+from typing import Any, Dict, Optional, Tuple
+import uuid
+
+from ts_agents.cli.output import to_jsonable
+from ts_agents.tools.executor import (
+    DockerBackend,
+    ExecutionContext,
+    ExecutionResult,
+    ExecutionStatus,
+    LocalBackend,
+    ModalBackend,
+    SandboxMode,
+    SubprocessBackend,
+    ToolError,
+    ToolErrorCode,
+    DaytonaBackend,
+    describe_sandbox_backend,
+)
+from ts_agents.tools.results import format_result, serialize_result
+
+from .registry import get_loop
+from .runner import run_autoresearch_loop
+
+_AUTORESEARCH_PREFIX = "autoresearch:"
+_SANDBOX_ARTIFACT_DIR_ENV = "TS_AGENTS_TOOL_ARTIFACT_DIR"
+_STAGED_AUTORESEARCH_ARTIFACTS_KEY = "_ts_agents_staged_autoresearch_artifacts"
+_AUTORESEARCH_ARTIFACT_MAX_FILE_BYTES_ENV = "TS_AGENTS_AUTORESEARCH_ARTIFACT_MAX_FILE_BYTES"
+_AUTORESEARCH_ARTIFACT_MAX_TOTAL_BYTES_ENV = "TS_AGENTS_AUTORESEARCH_ARTIFACT_MAX_TOTAL_BYTES"
+_WORKFLOW_ARTIFACT_MAX_FILE_BYTES_ENV = "TS_AGENTS_WORKFLOW_ARTIFACT_MAX_FILE_BYTES"
+_WORKFLOW_ARTIFACT_MAX_TOTAL_BYTES_ENV = "TS_AGENTS_WORKFLOW_ARTIFACT_MAX_TOTAL_BYTES"
+_DEFAULT_AUTORESEARCH_ARTIFACT_MAX_FILE_BYTES = 16 * 1024 * 1024
+_DEFAULT_AUTORESEARCH_ARTIFACT_MAX_TOTAL_BYTES = 64 * 1024 * 1024
+
+
+def _autoresearch_target_name(loop_name: str) -> str:
+    return f"{_AUTORESEARCH_PREFIX}{loop_name}"
+
+
+def is_autoresearch_target(tool_name: str) -> bool:
+    """Return whether a sandbox request targets an autoresearch loop."""
+    return tool_name.startswith(_AUTORESEARCH_PREFIX)
+
+
+def _parse_artifact_limit(var_names: tuple[str, ...], default: int) -> Optional[int]:
+    for var_name in var_names:
+        raw = os.environ.get(var_name)
+        if raw is None or not raw.strip():
+            continue
+        try:
+            value = int(raw.strip())
+        except ValueError:
+            return default
+        if value <= 0:
+            return None
+        return value
+    return default
+
+
+def _autoresearch_artifact_bundle_limits() -> Tuple[Optional[int], Optional[int]]:
+    return (
+        _parse_artifact_limit(
+            (_AUTORESEARCH_ARTIFACT_MAX_FILE_BYTES_ENV, _WORKFLOW_ARTIFACT_MAX_FILE_BYTES_ENV),
+            _DEFAULT_AUTORESEARCH_ARTIFACT_MAX_FILE_BYTES,
+        ),
+        _parse_artifact_limit(
+            (_AUTORESEARCH_ARTIFACT_MAX_TOTAL_BYTES_ENV, _WORKFLOW_ARTIFACT_MAX_TOTAL_BYTES_ENV),
+            _DEFAULT_AUTORESEARCH_ARTIFACT_MAX_TOTAL_BYTES,
+        ),
+    )
+
+
+def _run_serialized_autoresearch(
+    *,
+    loop_name: str,
+    options: Dict[str, Any],
+    use_sandbox_artifact_dir: bool = False,
+    sandbox_artifact_dir: Optional[str] = None,
+    bundle_sandbox_artifacts: bool = False,
+) -> Any:
+    resolved_options = dict(options or {})
+    staged_output_dir: Optional[Path] = None
+    if use_sandbox_artifact_dir:
+        artifact_root = (
+            sandbox_artifact_dir
+            or resolved_options.get("_sandbox_artifact_dir")
+            or os.environ.get(_SANDBOX_ARTIFACT_DIR_ENV)
+        )
+        if not artifact_root:
+            raise RuntimeError(
+                "sandbox_artifact_dir or "
+                f"{_SANDBOX_ARTIFACT_DIR_ENV} is required when use_sandbox_artifact_dir=true."
+            )
+        staged_output_dir = Path(artifact_root) / loop_name
+        resolved_options["output_dir"] = str(staged_output_dir)
+
+    result = run_autoresearch_loop(loop_name=loop_name, **resolved_options)
+    if staged_output_dir is not None and bundle_sandbox_artifacts:
+        return _attach_staged_autoresearch_artifacts(result, staged_output_dir)
+    return result
+
+
+def _attach_staged_autoresearch_artifacts(result: Any, output_dir: Path) -> Any:
+    payload = serialize_result(result)
+    if not isinstance(payload, dict):
+        return payload
+
+    max_file_bytes, max_total_bytes = _autoresearch_artifact_bundle_limits()
+    total_bytes = 0
+    staged_files = []
+    if output_dir.exists():
+        for file_path in sorted(output_dir.rglob("*")):
+            if not file_path.is_file():
+                continue
+            file_size = file_path.stat().st_size
+            relative_path = file_path.relative_to(output_dir).as_posix()
+            if max_file_bytes is not None and file_size > max_file_bytes:
+                _append_payload_warning(
+                    payload,
+                    f"Skipped remote artifact staging for '{relative_path}' because it exceeds {max_file_bytes} bytes. "
+                    f"Set {_AUTORESEARCH_ARTIFACT_MAX_FILE_BYTES_ENV} to override.",
+                )
+                continue
+            if max_total_bytes is not None and total_bytes + file_size > max_total_bytes:
+                _append_payload_warning(
+                    payload,
+                    f"Skipped remote artifact staging for '{relative_path}' because total bundle would exceed {max_total_bytes} bytes. "
+                    f"Set {_AUTORESEARCH_ARTIFACT_MAX_TOTAL_BYTES_ENV} to override.",
+                )
+                continue
+            content = file_path.read_bytes()
+            total_bytes += len(content)
+            staged_files.append(
+                {
+                    "source_path": str(file_path.resolve()),
+                    "relative_path": relative_path,
+                    "content_base64": base64.b64encode(content).decode("ascii"),
+                }
+            )
+
+    if staged_files:
+        payload[_STAGED_AUTORESEARCH_ARTIFACTS_KEY] = staged_files
+    return payload
+
+
+def execute_serialized_autoresearch_request(
+    *,
+    loop_name: str,
+    kwargs: Dict[str, Any],
+    context: Optional[ExecutionContext] = None,
+) -> ExecutionResult:
+    """Execute a serialized autoresearch request inside a sandbox runner."""
+    context = context or ExecutionContext(sandbox_mode=SandboxMode.LOCAL)
+    return LocalBackend().execute(
+        tool_name=_autoresearch_target_name(loop_name),
+        func=_run_serialized_autoresearch,
+        params=kwargs,
+        context=context,
+    )
+
+
+class AutoresearchExecutor:
+    """Execute autoresearch loops with the standard sandbox backends."""
+
+    def __init__(self) -> None:
+        self.backends = {
+            SandboxMode.LOCAL: LocalBackend(),
+            SandboxMode.DOCKER: DockerBackend(),
+            SandboxMode.DAYTONA: DaytonaBackend(),
+            SandboxMode.MODAL: ModalBackend(),
+            SandboxMode.SUBPROCESS: SubprocessBackend(),
+        }
+
+    def execute(
+        self,
+        loop_name: str,
+        options: Dict[str, Any],
+        *,
+        context: Optional[ExecutionContext] = None,
+    ) -> ExecutionResult:
+        context = context or ExecutionContext(sandbox_mode=SandboxMode.LOCAL)
+        try:
+            loop_definition = get_loop(loop_name)
+        except KeyError as exc:
+            return ExecutionResult(
+                status=ExecutionStatus.FAILED,
+                error=ToolError(
+                    code=ToolErrorCode.NOT_FOUND,
+                    message=str(exc),
+                    recoverable=False,
+                    tool_name=loop_name,
+                ),
+                metadata={"loop_name": loop_name},
+            )
+
+        requested_backend = context.sandbox_mode
+        actual_backend = context.sandbox_mode
+        backend = self.backends.get(requested_backend)
+        requested_status = describe_sandbox_backend(
+            requested_backend,
+            context=context,
+            backend=backend,
+        )
+        fallback_backend = context.fallback_backend or SandboxMode.LOCAL
+
+        if backend is None or not requested_status["available"] or not backend.is_available():
+            if not context.allow_fallback:
+                return ExecutionResult(
+                    status=ExecutionStatus.FAILED,
+                    error=ToolError(
+                        code=ToolErrorCode.BACKEND_UNAVAILABLE,
+                        message=(
+                            f"Requested backend '{requested_backend.value}' is unavailable and fallback is not allowed."
+                        ),
+                        recoverable=True,
+                        hint=requested_status.get("suggested_fix"),
+                        tool_name=loop_name,
+                        details={
+                            "backend_requested": requested_backend.value,
+                            "backend_status": requested_status,
+                            "fallback_allowed": False,
+                        },
+                    ),
+                    metadata={
+                        "loop_name": loop_name,
+                        "backend_requested": requested_backend.value,
+                        "backend_actual": None,
+                        "fallback_allowed": False,
+                        "fallback_used": False,
+                        "backend_status": requested_status,
+                    },
+                )
+
+            backend = self.backends.get(fallback_backend)
+            fallback_status = describe_sandbox_backend(
+                fallback_backend,
+                context=context,
+                backend=backend,
+            )
+            if backend is None or not fallback_status["available"] or not backend.is_available():
+                return ExecutionResult(
+                    status=ExecutionStatus.FAILED,
+                    error=ToolError(
+                        code=ToolErrorCode.BACKEND_UNAVAILABLE,
+                        message=(
+                            f"Requested backend '{requested_backend.value}' is unavailable and fallback backend "
+                            f"'{fallback_backend.value}' is also unavailable."
+                        ),
+                        recoverable=True,
+                        hint=fallback_status.get("suggested_fix") or requested_status.get("suggested_fix"),
+                        tool_name=loop_name,
+                    ),
+                    metadata={
+                        "loop_name": loop_name,
+                        "backend_requested": requested_backend.value,
+                        "backend_actual": None,
+                        "fallback_allowed": True,
+                        "fallback_backend": fallback_backend.value,
+                        "fallback_used": False,
+                        "backend_status": requested_status,
+                    },
+                )
+            actual_backend = fallback_backend
+
+        if actual_backend == SandboxMode.DAYTONA and loop_definition.required_extras:
+            env = dict(context.environment or {})
+            env.setdefault(
+                "TS_AGENTS_DAYTONA_INSTALL_EXTRAS",
+                ",".join(loop_definition.required_extras),
+            )
+            context.environment = env
+
+        requested_output_dir = dict(options or {}).get("output_dir")
+        request_payload = {
+            "loop_name": loop_name,
+            "options": dict(options or {}),
+            "use_sandbox_artifact_dir": _use_staged_autoresearch_artifact_dir(actual_backend),
+            "sandbox_artifact_dir": _sandbox_autoresearch_artifact_dir(actual_backend),
+            "bundle_sandbox_artifacts": _bundle_staged_autoresearch_artifacts(actual_backend),
+        }
+
+        result = backend.execute(
+            tool_name=_autoresearch_target_name(loop_name),
+            func=_run_serialized_autoresearch,
+            params=request_payload,
+            context=context,
+        )
+        result.metadata = {
+            **(result.metadata or {}),
+            "loop_name": loop_name,
+            "backend_requested": requested_backend.value,
+            "backend_actual": actual_backend.value,
+            "fallback_used": actual_backend != requested_backend,
+            "fallback_allowed": context.allow_fallback,
+            "fallback_backend": fallback_backend.value if context.allow_fallback else None,
+        }
+
+        if result.success and actual_backend == SandboxMode.DOCKER and requested_output_dir:
+            _materialize_existing_artifacts(result, requested_output_dir)
+        elif result.success and actual_backend in {SandboxMode.DAYTONA, SandboxMode.MODAL}:
+            _materialize_remote_autoresearch_output(result, requested_output_dir)
+        return result
+
+
+def _use_staged_autoresearch_artifact_dir(backend: SandboxMode) -> bool:
+    return backend in {SandboxMode.DOCKER, SandboxMode.DAYTONA, SandboxMode.MODAL}
+
+
+def _bundle_staged_autoresearch_artifacts(backend: SandboxMode) -> bool:
+    return backend in {SandboxMode.DAYTONA, SandboxMode.MODAL}
+
+
+def _sandbox_autoresearch_artifact_dir(backend: SandboxMode) -> Optional[str]:
+    if backend == SandboxMode.DOCKER:
+        return "/io/artifacts"
+    if backend == SandboxMode.DAYTONA:
+        return f".ts_agents_io/artifacts/{uuid.uuid4().hex[:8]}"
+    if backend == SandboxMode.MODAL:
+        return f"/tmp/ts_agents_autoresearch_artifacts/{uuid.uuid4().hex[:8]}"
+    return None
+
+
+def _append_payload_warning(payload: Dict[str, Any], warning: str) -> None:
+    warnings = payload.get("warnings")
+    if not isinstance(warnings, list):
+        warnings = []
+        payload["warnings"] = warnings
+    if warning not in warnings:
+        warnings.append(warning)
+
+
+def _materialize_existing_artifacts(result: ExecutionResult, requested_output_dir: str) -> None:
+    payload = result.result
+    if not isinstance(payload, dict):
+        return
+    artifacts = payload.get("artifacts")
+    if not isinstance(artifacts, list):
+        return
+
+    destination_dir = Path(requested_output_dir).resolve()
+    destination_dir.mkdir(parents=True, exist_ok=True)
+    rewritten: dict[str, Path] = {}
+    for artifact in artifacts:
+        if not isinstance(artifact, dict):
+            continue
+        source_path = artifact.get("path")
+        if not isinstance(source_path, str):
+            continue
+        source = Path(source_path)
+        if not source.exists():
+            continue
+        destination = destination_dir / source.name
+        if source.resolve() != destination.resolve():
+            shutil.copy2(source, destination)
+        rewritten[source_path] = destination
+        artifact["path"] = str(destination)
+
+    _rewrite_payload_paths(payload, destination_dir, rewritten)
+    result.formatted_output = format_result(payload)
+
+
+def _materialize_remote_autoresearch_output(
+    result: ExecutionResult,
+    requested_output_dir: Optional[str],
+) -> None:
+    payload = result.result
+    if not isinstance(payload, dict):
+        return
+    staged_files = payload.pop(_STAGED_AUTORESEARCH_ARTIFACTS_KEY, None)
+    if not isinstance(staged_files, list) or not staged_files:
+        return
+
+    destination_root = (
+        Path(requested_output_dir).resolve()
+        if requested_output_dir
+        else Path(tempfile.mkdtemp(prefix="ts_agents_autoresearch_output_")).resolve()
+    )
+    destination_root.mkdir(parents=True, exist_ok=True)
+    rewritten: dict[str, Path] = {}
+    for staged_file in staged_files:
+        if not isinstance(staged_file, dict):
+            continue
+        relative_path = staged_file.get("relative_path")
+        content_base64 = staged_file.get("content_base64")
+        source_path = staged_file.get("source_path")
+        if not isinstance(relative_path, str) or not isinstance(content_base64, str):
+            continue
+        candidate = Path(relative_path)
+        if candidate.is_absolute():
+            _append_payload_warning(
+                payload,
+                f"Skipped restoring remote artifact '{relative_path}' because absolute paths are not allowed.",
+            )
+            continue
+        destination = (destination_root / candidate).resolve(strict=False)
+        try:
+            destination.relative_to(destination_root)
+        except ValueError:
+            _append_payload_warning(
+                payload,
+                f"Skipped restoring remote artifact '{relative_path}' because it escapes the output directory.",
+            )
+            continue
+        try:
+            content = base64.b64decode(content_base64.encode("ascii"))
+        except (ValueError, binascii.Error):
+            _append_payload_warning(
+                payload,
+                f"Skipped restoring remote artifact '{relative_path}' because its payload was not valid base64.",
+            )
+            continue
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        destination.write_bytes(content)
+        if isinstance(source_path, str):
+            rewritten[source_path] = destination
+
+    _rewrite_remote_artifact_refs(payload, rewritten)
+    _rewrite_payload_paths(payload, destination_root, rewritten)
+    result.formatted_output = format_result(payload)
+
+
+def _rewrite_remote_artifact_refs(payload: Dict[str, Any], rewritten: dict[str, Path]) -> None:
+    artifacts = payload.get("artifacts")
+    if not isinstance(artifacts, list):
+        return
+    for artifact in artifacts:
+        if not isinstance(artifact, dict):
+            continue
+        source_path = artifact.get("path")
+        if not isinstance(source_path, str):
+            continue
+        destination = rewritten.get(source_path)
+        if destination is not None:
+            artifact["path"] = str(destination)
+        else:
+            _append_payload_warning(
+                payload,
+                f"Artifact '{source_path}' was not staged and remains inaccessible on the host.",
+            )
+
+
+def _rewrite_payload_paths(
+    payload: Dict[str, Any],
+    destination_dir: Path,
+    rewritten: dict[str, Path],
+) -> None:
+    data = payload.get("data")
+    if not isinstance(data, dict):
+        return
+    data["output_dir"] = str(destination_dir)
+    manifest_path = data.get("manifest_path")
+    if isinstance(manifest_path, str) and manifest_path in rewritten:
+        data["manifest_path"] = str(rewritten[manifest_path])
+    elif isinstance(manifest_path, str):
+        data["manifest_path"] = str(destination_dir / Path(manifest_path).name)
+
+    best_config = data.get("best_config")
+    if best_config is not None:
+        data["best_config"] = to_jsonable(best_config)
+
+
+_DEFAULT_EXECUTOR: Optional[AutoresearchExecutor] = None
+
+
+def get_executor() -> AutoresearchExecutor:
+    """Return the default autoresearch executor."""
+    global _DEFAULT_EXECUTOR
+    if _DEFAULT_EXECUTOR is None:
+        _DEFAULT_EXECUTOR = AutoresearchExecutor()
+    return _DEFAULT_EXECUTOR
+
+
+def execute_autoresearch(
+    loop_name: str,
+    options: Dict[str, Any],
+    *,
+    context: Optional[ExecutionContext] = None,
+) -> ExecutionResult:
+    """Execute an autoresearch loop through the default executor."""
+    return get_executor().execute(loop_name, options, context=context)

--- a/ts_agents/autoresearch/executor.py
+++ b/ts_agents/autoresearch/executor.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 
 import base64
 import binascii
+from dataclasses import replace
+from importlib.util import find_spec
 import os
 from pathlib import Path
-import shutil
 import tempfile
 from typing import Any, Dict, Optional, Tuple
 import uuid
@@ -40,6 +41,8 @@ _WORKFLOW_ARTIFACT_MAX_FILE_BYTES_ENV = "TS_AGENTS_WORKFLOW_ARTIFACT_MAX_FILE_BY
 _WORKFLOW_ARTIFACT_MAX_TOTAL_BYTES_ENV = "TS_AGENTS_WORKFLOW_ARTIFACT_MAX_TOTAL_BYTES"
 _DEFAULT_AUTORESEARCH_ARTIFACT_MAX_FILE_BYTES = 16 * 1024 * 1024
 _DEFAULT_AUTORESEARCH_ARTIFACT_MAX_TOTAL_BYTES = 64 * 1024 * 1024
+_STATSFORECAST_METHODS = {"theta", "ets", "arima"}
+_CLASSIFICATION_METHODS = {"knn", "minirocket", "rocket"}
 
 
 def _autoresearch_target_name(loop_name: str) -> str:
@@ -77,6 +80,67 @@ def _autoresearch_artifact_bundle_limits() -> Tuple[Optional[int], Optional[int]
             _DEFAULT_AUTORESEARCH_ARTIFACT_MAX_TOTAL_BYTES,
         ),
     )
+
+
+def _enforce_host_availability_for_backend(backend: SandboxMode) -> bool:
+    return backend in {SandboxMode.LOCAL, SandboxMode.SUBPROCESS}
+
+
+def _selected_models_for_availability(
+    loop_definition: Any, options: Dict[str, Any]
+) -> list[str]:
+    models = options.get("models")
+    if models is None:
+        return list(loop_definition.models)
+    return [
+        str(model).strip()
+        for model in models
+        if model is not None and str(model).strip()
+    ]
+
+
+def _autoresearch_availability(
+    loop_definition: Any, options: Dict[str, Any]
+) -> Dict[str, Any]:
+    models = _selected_models_for_availability(loop_definition, options)
+    missing: list[str] = []
+    if loop_definition.name == "forecast-daytona" and set(models).intersection(
+        _STATSFORECAST_METHODS
+    ):
+        if find_spec("statsforecast") is None:
+            missing.append("statsforecast")
+    if loop_definition.name == "classify-daytona" and set(models).intersection(
+        _CLASSIFICATION_METHODS
+    ):
+        if find_spec("aeon") is None:
+            missing.append("aeon")
+        if find_spec("sklearn") is None:
+            missing.append("scikit-learn")
+    if not missing:
+        return {"available": True, "missing": []}
+    extra = (
+        "forecasting"
+        if loop_definition.name == "forecast-daytona"
+        else "classification"
+    )
+    return {
+        "available": False,
+        "missing": missing,
+        "install_hint": f"Autoresearch loop {loop_definition.name!r} requires optional dependencies: "
+        f"{', '.join(missing)}. Install with: pip install 'ts-agents[{extra}]'",
+    }
+
+
+def _context_with_loop_environment(
+    context: ExecutionContext,
+    loop_definition: Any,
+    actual_backend: SandboxMode,
+) -> ExecutionContext:
+    if actual_backend != SandboxMode.DAYTONA or not loop_definition.required_extras:
+        return context
+    env = dict(context.environment or {})
+    env["TS_AGENTS_DAYTONA_INSTALL_EXTRAS"] = ",".join(loop_definition.required_extras)
+    return replace(context, environment=env)
 
 
 def _run_serialized_autoresearch(
@@ -212,7 +276,11 @@ class AutoresearchExecutor:
         )
         fallback_backend = context.fallback_backend or SandboxMode.LOCAL
 
-        if backend is None or not requested_status["available"] or not backend.is_available():
+        if (
+            backend is None
+            or not requested_status["available"]
+            or not backend.is_available()
+        ):
             if not context.allow_fallback:
                 return ExecutionResult(
                     status=ExecutionStatus.FAILED,
@@ -246,7 +314,11 @@ class AutoresearchExecutor:
                 context=context,
                 backend=backend,
             )
-            if backend is None or not fallback_status["available"] or not backend.is_available():
+            if (
+                backend is None
+                or not fallback_status["available"]
+                or not backend.is_available()
+            ):
                 return ExecutionResult(
                     status=ExecutionStatus.FAILED,
                     error=ToolError(
@@ -256,7 +328,8 @@ class AutoresearchExecutor:
                             f"'{fallback_backend.value}' is also unavailable."
                         ),
                         recoverable=True,
-                        hint=fallback_status.get("suggested_fix") or requested_status.get("suggested_fix"),
+                        hint=fallback_status.get("suggested_fix")
+                        or requested_status.get("suggested_fix"),
                         tool_name=loop_name,
                     ),
                     metadata={
@@ -271,28 +344,55 @@ class AutoresearchExecutor:
                 )
             actual_backend = fallback_backend
 
-        if actual_backend == SandboxMode.DAYTONA and loop_definition.required_extras:
-            env = dict(context.environment or {})
-            env.setdefault(
-                "TS_AGENTS_DAYTONA_INSTALL_EXTRAS",
-                ",".join(loop_definition.required_extras),
+        availability = _autoresearch_availability(loop_definition, dict(options or {}))
+        if _enforce_host_availability_for_backend(
+            actual_backend
+        ) and not availability.get("available", True):
+            return ExecutionResult(
+                status=ExecutionStatus.FAILED,
+                error=ToolError(
+                    code=ToolErrorCode.DEPENDENCY_ERROR,
+                    message=availability.get("install_hint")
+                    or f"Autoresearch loop '{loop_name}' is unavailable in the current environment.",
+                    recoverable=False,
+                    tool_name=loop_name,
+                    details={"availability": availability},
+                ),
+                metadata={
+                    "loop_name": loop_name,
+                    "backend_requested": requested_backend.value,
+                    "backend_actual": actual_backend.value,
+                    "fallback_allowed": context.allow_fallback,
+                    "fallback_backend": fallback_backend.value
+                    if context.allow_fallback
+                    else None,
+                    "fallback_used": actual_backend != requested_backend,
+                    "availability": availability,
+                },
             )
-            context.environment = env
+
+        execution_context = _context_with_loop_environment(
+            context, loop_definition, actual_backend
+        )
 
         requested_output_dir = dict(options or {}).get("output_dir")
         request_payload = {
             "loop_name": loop_name,
             "options": dict(options or {}),
-            "use_sandbox_artifact_dir": _use_staged_autoresearch_artifact_dir(actual_backend),
+            "use_sandbox_artifact_dir": _use_staged_autoresearch_artifact_dir(
+                actual_backend
+            ),
             "sandbox_artifact_dir": _sandbox_autoresearch_artifact_dir(actual_backend),
-            "bundle_sandbox_artifacts": _bundle_staged_autoresearch_artifacts(actual_backend),
+            "bundle_sandbox_artifacts": _bundle_staged_autoresearch_artifacts(
+                actual_backend
+            ),
         }
 
         result = backend.execute(
             tool_name=_autoresearch_target_name(loop_name),
             func=_run_serialized_autoresearch,
             params=request_payload,
-            context=context,
+            context=execution_context,
         )
         result.metadata = {
             **(result.metadata or {}),
@@ -301,12 +401,21 @@ class AutoresearchExecutor:
             "backend_actual": actual_backend.value,
             "fallback_used": actual_backend != requested_backend,
             "fallback_allowed": context.allow_fallback,
-            "fallback_backend": fallback_backend.value if context.allow_fallback else None,
+            "fallback_backend": fallback_backend.value
+            if context.allow_fallback
+            else None,
         }
 
-        if result.success and actual_backend == SandboxMode.DOCKER and requested_output_dir:
+        if (
+            result.success
+            and actual_backend == SandboxMode.DOCKER
+            and requested_output_dir
+        ):
             _materialize_existing_artifacts(result, requested_output_dir)
-        elif result.success and actual_backend in {SandboxMode.DAYTONA, SandboxMode.MODAL}:
+        elif result.success and actual_backend in {
+            SandboxMode.DAYTONA,
+            SandboxMode.MODAL,
+        }:
             _materialize_remote_autoresearch_output(result, requested_output_dir)
         return result
 
@@ -321,7 +430,7 @@ def _bundle_staged_autoresearch_artifacts(backend: SandboxMode) -> bool:
 
 def _sandbox_autoresearch_artifact_dir(backend: SandboxMode) -> Optional[str]:
     if backend == SandboxMode.DOCKER:
-        return "/io/artifacts"
+        return f"/io/artifacts/{uuid.uuid4().hex[:8]}"
     if backend == SandboxMode.DAYTONA:
         return f".ts_agents_io/artifacts/{uuid.uuid4().hex[:8]}"
     if backend == SandboxMode.MODAL:
@@ -338,7 +447,103 @@ def _append_payload_warning(payload: Dict[str, Any], warning: str) -> None:
         warnings.append(warning)
 
 
-def _materialize_existing_artifacts(result: ExecutionResult, requested_output_dir: str) -> None:
+def _path_contains_symlink(path: Path) -> bool:
+    current = Path(path.anchor) if path.is_absolute() else Path.cwd()
+    parts = path.parts[1:] if path.is_absolute() else path.parts
+    for part in parts:
+        current = current / part
+        if current.is_symlink():
+            return True
+        if not current.exists():
+            return False
+    return False
+
+
+def _valid_relative_artifact_path(relative_path: str) -> Optional[Path]:
+    candidate = Path(relative_path)
+    if candidate.is_absolute() or not candidate.parts:
+        return None
+    if any(part in {"", ".", ".."} for part in candidate.parts):
+        return None
+    return candidate
+
+
+def _safe_destination_for_relative_path(
+    destination_root: Path,
+    relative_path: str,
+    payload: Dict[str, Any],
+) -> Optional[Path]:
+    candidate = _valid_relative_artifact_path(relative_path)
+    if candidate is None:
+        _append_payload_warning(
+            payload,
+            f"Skipped restoring artifact '{relative_path}' because it is not a safe relative path.",
+        )
+        return None
+
+    parent = destination_root
+    for part in candidate.parts[:-1]:
+        parent = parent / part
+        if parent.is_symlink():
+            _append_payload_warning(
+                payload,
+                f"Skipped restoring artifact '{relative_path}' because a destination directory is a symlink.",
+            )
+            return None
+        try:
+            parent.mkdir(exist_ok=True)
+        except OSError as exc:
+            _append_payload_warning(
+                payload,
+                f"Skipped restoring artifact '{relative_path}' because its destination directory could not be created: {exc}",
+            )
+            return None
+        if not parent.is_dir() or parent.is_symlink():
+            _append_payload_warning(
+                payload,
+                f"Skipped restoring artifact '{relative_path}' because its destination directory is unsafe.",
+            )
+            return None
+
+    destination = parent / candidate.name
+    if destination.is_symlink():
+        _append_payload_warning(
+            payload,
+            f"Skipped restoring artifact '{relative_path}' because the destination is a symlink.",
+        )
+        return None
+    return destination
+
+
+def _relative_artifact_path(source: Path, source_root: Optional[Path]) -> str:
+    if source_root is not None:
+        try:
+            relative = source.resolve().relative_to(source_root)
+            safe = _valid_relative_artifact_path(relative.as_posix())
+            if safe is not None:
+                return safe.as_posix()
+        except ValueError:
+            pass
+    return source.name
+
+
+def _write_bytes_atomically(destination: Path, content: bytes) -> None:
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    temp_path = destination.with_name(f".{destination.name}.{uuid.uuid4().hex}.tmp")
+    try:
+        temp_path.write_bytes(content)
+        os.replace(temp_path, destination)
+    finally:
+        try:
+            if temp_path.exists():
+                temp_path.unlink()
+        except OSError:
+            pass
+
+
+def _materialize_existing_artifacts(
+    result: ExecutionResult, requested_output_dir: str
+) -> None:
     payload = result.result
     if not isinstance(payload, dict):
         return
@@ -346,8 +551,19 @@ def _materialize_existing_artifacts(result: ExecutionResult, requested_output_di
     if not isinstance(artifacts, list):
         return
 
-    destination_dir = Path(requested_output_dir).resolve()
+    destination_dir = Path(requested_output_dir).expanduser().absolute()
+    if _path_contains_symlink(destination_dir):
+        _append_payload_warning(
+            payload,
+            f"Skipped restoring Docker artifacts because output directory '{destination_dir}' contains a symlink component.",
+        )
+        return
     destination_dir.mkdir(parents=True, exist_ok=True)
+    data = payload.get("data") if isinstance(payload.get("data"), dict) else {}
+    source_root_raw = data.get("output_dir") if isinstance(data, dict) else None
+    source_root = (
+        Path(source_root_raw).resolve() if isinstance(source_root_raw, str) else None
+    )
     rewritten: dict[str, Path] = {}
     for artifact in artifacts:
         if not isinstance(artifact, dict):
@@ -356,11 +572,23 @@ def _materialize_existing_artifacts(result: ExecutionResult, requested_output_di
         if not isinstance(source_path, str):
             continue
         source = Path(source_path)
-        if not source.exists():
+        if not source.exists() or not source.is_file():
             continue
-        destination = destination_dir / source.name
-        if source.resolve() != destination.resolve():
-            shutil.copy2(source, destination)
+        relative_path = _relative_artifact_path(source, source_root)
+        destination = _safe_destination_for_relative_path(
+            destination_dir, relative_path, payload
+        )
+        if destination is None:
+            continue
+        if source.resolve() != destination.resolve(strict=False):
+            try:
+                _write_bytes_atomically(destination, source.read_bytes())
+            except OSError as exc:
+                _append_payload_warning(
+                    payload,
+                    f"Skipped restoring Docker artifact '{relative_path}' because it could not be written: {exc}",
+                )
+                continue
         rewritten[source_path] = destination
         artifact["path"] = str(destination)
 
@@ -380,10 +608,16 @@ def _materialize_remote_autoresearch_output(
         return
 
     destination_root = (
-        Path(requested_output_dir).resolve()
+        Path(requested_output_dir).expanduser().absolute()
         if requested_output_dir
-        else Path(tempfile.mkdtemp(prefix="ts_agents_autoresearch_output_")).resolve()
+        else Path(tempfile.mkdtemp(prefix="ts_agents_autoresearch_output_")).absolute()
     )
+    if _path_contains_symlink(destination_root):
+        _append_payload_warning(
+            payload,
+            f"Skipped restoring remote artifacts because output directory '{destination_root}' contains a symlink component.",
+        )
+        return
     destination_root.mkdir(parents=True, exist_ok=True)
     rewritten: dict[str, Path] = {}
     for staged_file in staged_files:
@@ -394,21 +628,10 @@ def _materialize_remote_autoresearch_output(
         source_path = staged_file.get("source_path")
         if not isinstance(relative_path, str) or not isinstance(content_base64, str):
             continue
-        candidate = Path(relative_path)
-        if candidate.is_absolute():
-            _append_payload_warning(
-                payload,
-                f"Skipped restoring remote artifact '{relative_path}' because absolute paths are not allowed.",
-            )
-            continue
-        destination = (destination_root / candidate).resolve(strict=False)
-        try:
-            destination.relative_to(destination_root)
-        except ValueError:
-            _append_payload_warning(
-                payload,
-                f"Skipped restoring remote artifact '{relative_path}' because it escapes the output directory.",
-            )
+        destination = _safe_destination_for_relative_path(
+            destination_root, relative_path, payload
+        )
+        if destination is None:
             continue
         try:
             content = base64.b64decode(content_base64.encode("ascii"))
@@ -418,8 +641,14 @@ def _materialize_remote_autoresearch_output(
                 f"Skipped restoring remote artifact '{relative_path}' because its payload was not valid base64.",
             )
             continue
-        destination.parent.mkdir(parents=True, exist_ok=True)
-        destination.write_bytes(content)
+        try:
+            _write_bytes_atomically(destination, content)
+        except OSError as exc:
+            _append_payload_warning(
+                payload,
+                f"Skipped restoring remote artifact '{relative_path}' because it could not be written: {exc}",
+            )
+            continue
         if isinstance(source_path, str):
             rewritten[source_path] = destination
 
@@ -428,7 +657,9 @@ def _materialize_remote_autoresearch_output(
     result.formatted_output = format_result(payload)
 
 
-def _rewrite_remote_artifact_refs(payload: Dict[str, Any], rewritten: dict[str, Path]) -> None:
+def _rewrite_remote_artifact_refs(
+    payload: Dict[str, Any], rewritten: dict[str, Path]
+) -> None:
     artifacts = payload.get("artifacts")
     if not isinstance(artifacts, list):
         return

--- a/ts_agents/autoresearch/executor.py
+++ b/ts_agents/autoresearch/executor.py
@@ -59,7 +59,7 @@ def _parse_artifact_limit(var_names: tuple[str, ...], default: int) -> Optional[
         try:
             value = int(raw.strip())
         except ValueError:
-            return default
+            continue
         if value <= 0:
             return None
         return value

--- a/ts_agents/autoresearch/registry.py
+++ b/ts_agents/autoresearch/registry.py
@@ -1,0 +1,167 @@
+"""Registry for built-in autoresearch loops."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from typing import Any
+
+
+@dataclass(frozen=True)
+class AutoresearchBudget:
+    """Default resource budget for an autoresearch loop."""
+
+    timeout_seconds: int
+    vcpu: int
+    memory_mb: int
+    disk_mb: int
+    max_trials: int
+    notes: list[str] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class AutoresearchLoopDefinition:
+    """Machine-readable metadata for one autoresearch loop."""
+
+    name: str
+    task: str
+    description: str
+    dataset: str
+    models: list[str]
+    primary_metric: str
+    secondary_metrics: list[str]
+    budget: AutoresearchBudget
+    required_extras: list[str] = field(default_factory=list)
+    output_root: str = "outputs/autoresearch"
+    capabilities: dict[str, Any] = field(default_factory=dict)
+
+
+_DAYTONA_BUDGET = AutoresearchBudget(
+    timeout_seconds=20 * 60,
+    vcpu=4,
+    memory_mb=8 * 1024,
+    disk_mb=10 * 1024,
+    max_trials=60,
+    notes=[
+        "Designed for Daytona sandboxes capped at 4 vCPU, 8 GiB RAM, and 10 GiB disk.",
+        "Default data sources are vendored or generated locally; no dataset download is required.",
+    ],
+)
+
+
+_LOOPS: dict[str, AutoresearchLoopDefinition] = {
+    "forecast-daytona": AutoresearchLoopDefinition(
+        name="forecast-daytona",
+        task="forecasting",
+        description=(
+            "Compare statistical forecasting baselines on the vendored M4 Monthly mini panel "
+            "under constrained Daytona-style resources."
+        ),
+        dataset="data/m4_monthly_mini.csv",
+        models=["seasonal_naive", "theta", "ets", "arima"],
+        primary_metric="smape",
+        secondary_metrics=["mae", "rmse", "mape", "elapsed_seconds", "failure_rate"],
+        budget=_DAYTONA_BUDGET,
+        required_extras=["forecasting"],
+        capabilities={
+            "horizon": 18,
+            "season_length": 12,
+            "default_series": ["M4", "M10", "M100", "M1000", "M1002"],
+            "rolling_origins": 2,
+            "max_trials_semantics": "number of model/evaluation-spec rows",
+            "search_style": "benchmark sweep",
+            "ranking_rule": "lowest mean sMAPE across holdout and rolling-origin rows; MAE and RMSE are tie-breakers",
+        },
+    ),
+    "classify-daytona": AutoresearchLoopDefinition(
+        name="classify-daytona",
+        task="classification",
+        description=(
+            "Compare windowed time-series classifiers on a vendored or generated labeled "
+            "activity stream under constrained Daytona-style resources."
+        ),
+        dataset="data/wisdm_subset.csv with generated synthetic fallback",
+        models=["knn", "minirocket", "rocket"],
+        primary_metric="balanced_accuracy",
+        secondary_metrics=["best_window_size", "n_windows", "elapsed_seconds", "failure_rate"],
+        budget=AutoresearchBudget(
+            timeout_seconds=20 * 60,
+            vcpu=4,
+            memory_mb=8 * 1024,
+            disk_mb=10 * 1024,
+            max_trials=3,
+            notes=list(_DAYTONA_BUDGET.notes),
+        ),
+        required_extras=["classification"],
+        capabilities={
+            "window_sizes": [32, 64, 96, 128, 160],
+            "labeling": "strict",
+            "balance": "segment_cap",
+            "max_windows_per_segment": 25,
+            "n_splits": 3,
+            "seed": 1337,
+            "max_trials_semantics": "number of model/evaluation-spec rows",
+            "search_style": "benchmark sweep with per-classifier window-size selection",
+            "ranking_rule": "highest balanced accuracy from window-selection CV; smaller selected window and more retained windows are tie-breakers",
+        },
+    ),
+    "foundation-gpu-plan": AutoresearchLoopDefinition(
+        name="foundation-gpu-plan",
+        task="foundation-model-plan",
+        description=(
+            "Materialize an RTX PRO 6000 Blackwell-oriented, plan-only foundation-model "
+            "research recipe covering Chronos-family forecasting and MOMENT classification."
+        ),
+        dataset="vendored M4 mini and generated/vendored labeled streams for smoke runs",
+        models=["amazon/chronos-2", "amazon/chronos-t5-small", "AutonLab/MOMENT-1-large"],
+        primary_metric="not_applicable_plan_only",
+        secondary_metrics=["planned_wall_time", "planned_gpu_memory_gb", "checkpoint_cap_gb"],
+        budget=AutoresearchBudget(
+            timeout_seconds=4 * 60 * 60,
+            vcpu=16,
+            memory_mb=64 * 1024,
+            disk_mb=200 * 1024,
+            max_trials=6,
+            notes=[
+                "Assumes one RTX PRO 6000 Blackwell GPU.",
+                "Heavy foundation-model packages are intentionally optional and lazy-loaded.",
+            ],
+        ),
+        required_extras=[],
+        capabilities={
+            "status": "plan-only",
+            "generates_metrics": False,
+            "forecasting_model": "amazon/chronos-2",
+            "forecasting_model_revision": "254b5357164a84326913b0695216f690752ac55d",
+            "forecasting_finetune_fallback": "amazon/chronos-t5-small",
+            "forecasting_finetune_revision": "4753ebecb99f65f84cd2823c56f7ab22b02ac303",
+            "classification_model": "AutonLab/MOMENT-1-large",
+            "classification_model_revision": "3582f9d7f033eea9d43e6a802ba0e36d5f26b57c",
+            "smoke_budget": "30 minutes, 1 seed, 1 epoch or 1000 max steps",
+            "full_budget": "4 hours, 3 seeds, early stopping, bf16, checkpoint cap 5 GiB",
+        },
+    ),
+}
+
+
+def list_loops() -> list[AutoresearchLoopDefinition]:
+    """Return built-in autoresearch loop definitions."""
+    return list(_LOOPS.values())
+
+
+def get_loop(name: str) -> AutoresearchLoopDefinition:
+    """Return a built-in autoresearch loop definition by name."""
+    try:
+        return _LOOPS[name]
+    except KeyError as exc:
+        available = ", ".join(sorted(_LOOPS))
+        raise KeyError(f"Unknown autoresearch loop '{name}'. Available: {available}.") from exc
+
+
+def loop_to_dict(loop: AutoresearchLoopDefinition) -> dict[str, Any]:
+    """Convert a loop definition to a stable JSON-compatible dictionary."""
+    payload = asdict(loop)
+    payload["cli_templates"] = [
+        f"ts-agents autoresearch show {loop.name} --json",
+        f"ts-agents autoresearch run {loop.name} --json",
+    ]
+    return payload

--- a/ts_agents/autoresearch/runner.py
+++ b/ts_agents/autoresearch/runner.py
@@ -71,7 +71,7 @@ def run_autoresearch_loop(
     run_id = generate_workflow_run_id()
     budget_timeout = int(timeout_seconds or definition.budget.timeout_seconds)
     selected_models = _normalize_models(loop_name, models)
-    trial_limit = int(max_trials or definition.budget.max_trials)
+    trial_limit = int(definition.budget.max_trials if max_trials is None else max_trials)
     if trial_limit <= 0:
         raise ValueError("--max-trials must be a positive integer.")
 
@@ -170,6 +170,7 @@ def _run_forecast_daytona(**kwargs: Any) -> dict[str, Any]:
     warnings.extend(_forecast_ranking_warnings(trials))
     best_config = ranking[0] if ranking else {}
     status = "degraded" if warnings or any(row.get("status") == "failed" for row in trials) else "ok"
+    plot_artifacts = [] if skip_plots or dry_run else _write_forecast_plot(output_path, trials)
     artifacts = _write_autoresearch_artifacts(
         output_path=output_path,
         loop_name="forecast-daytona",
@@ -199,9 +200,8 @@ def _run_forecast_daytona(**kwargs: Any) -> dict[str, Any]:
         extra_json={"model_ranking": ranking},
         status=status,
         warnings=warnings,
+        extra_artifacts=plot_artifacts,
     )
-    if not skip_plots and not dry_run:
-        artifacts.extend(_write_forecast_plot(output_path, trials))
 
     return _result_payload(
         loop_name="forecast-daytona",
@@ -283,6 +283,7 @@ def _run_classify_daytona(**kwargs: Any) -> dict[str, Any]:
     ranking = _rank_classification_trials(trials)
     best_config = ranking[0] if ranking else {}
     status = "degraded" if warnings or any(row.get("status") == "failed" for row in trials) else "ok"
+    plot_artifacts = [] if skip_plots or dry_run else _write_classification_plot(output_path, trials)
     artifacts = list(dataset_artifacts)
     artifacts.extend(
         _write_autoresearch_artifacts(
@@ -317,10 +318,9 @@ def _run_classify_daytona(**kwargs: Any) -> dict[str, Any]:
             extra_json={"model_ranking": ranking},
             status=status,
             warnings=warnings,
+            extra_artifacts=plot_artifacts,
         )
     )
-    if not skip_plots and not dry_run:
-        artifacts.extend(_write_classification_plot(output_path, trials))
 
     return _result_payload(
         loop_name="classify-daytona",
@@ -770,7 +770,15 @@ def _rank_forecast_trials(trials: list[dict[str, Any]]) -> list[dict[str, Any]]:
                 "n_rolling_trials": len(rolling_rows),
             }
         )
-    return sorted(ranking, key=lambda row: (row["smape"], row["mae"], row["rmse"]))
+    return sorted(
+        ranking,
+        key=lambda row: (
+            _sort_low_metric(row.get("smape")),
+            _sort_low_metric(row.get("mae")),
+            _sort_low_metric(row.get("rmse")),
+            str(row.get("model", "")),
+        ),
+    )
 
 
 def _forecast_ranking_warnings(trials: list[dict[str, Any]]) -> list[str]:
@@ -815,9 +823,24 @@ def _rank_classification_trials(trials: list[dict[str, Any]]) -> list[dict[str, 
     )
 
 
-def _mean_metric(rows: list[dict[str, Any]], key: str) -> float:
-    values = [float(row[key]) for row in rows if isinstance(row.get(key), (int, float))]
-    return float(np.mean(values)) if values else float("nan")
+def _sort_low_metric(value: Any) -> float:
+    if isinstance(value, (int, float, np.integer, np.floating)):
+        number = float(value)
+        if np.isfinite(number):
+            return number
+    return float("inf")
+
+
+def _mean_metric(rows: list[dict[str, Any]], key: str) -> Optional[float]:
+    values = []
+    for row in rows:
+        value = row.get(key)
+        if not isinstance(value, (int, float, np.integer, np.floating)):
+            continue
+        number = float(value)
+        if np.isfinite(number):
+            values.append(number)
+    return float(np.mean(values)) if values else None
 
 
 def _write_autoresearch_artifacts(
@@ -834,6 +857,7 @@ def _write_autoresearch_artifacts(
     extra_json: Optional[dict[str, Any]] = None,
     status: str = "ok",
     warnings: Optional[list[str]] = None,
+    extra_artifacts: Optional[list[ArtifactRef]] = None,
 ) -> list[ArtifactRef]:
     trials_df = pd.DataFrame(trials)
     artifacts = [
@@ -844,6 +868,7 @@ def _write_autoresearch_artifacts(
     ]
     if extra_json:
         artifacts.append(_write_json(output_path / "summary.json", extra_json, "Autoresearch loop summary."))
+    artifacts.extend(extra_artifacts or [])
     manifest = _manifest_payload(
         loop_name=loop_name,
         run_id=run_id,
@@ -1033,15 +1058,18 @@ def _trial_timeout(seconds: Optional[float]):
 
     previous_handler = signal.getsignal(signal.SIGALRM)
     previous_timer = signal.getitimer(signal.ITIMER_REAL)
+    armed_at = time.monotonic()
     signal.signal(signal.SIGALRM, _raise_timeout)
     signal.setitimer(signal.ITIMER_REAL, float(seconds))
     try:
         yield
     finally:
+        elapsed = time.monotonic() - armed_at
         signal.setitimer(signal.ITIMER_REAL, 0.0)
         signal.signal(signal.SIGALRM, previous_handler)
         if previous_timer[0] > 0:
-            signal.setitimer(signal.ITIMER_REAL, previous_timer[0], previous_timer[1])
+            remaining = max(0.001, previous_timer[0] - elapsed)
+            signal.setitimer(signal.ITIMER_REAL, remaining, previous_timer[1])
 
 
 def _utc_now() -> str:

--- a/ts_agents/autoresearch/runner.py
+++ b/ts_agents/autoresearch/runner.py
@@ -69,9 +69,15 @@ def run_autoresearch_loop(
 
     started_at = _utc_now()
     run_id = generate_workflow_run_id()
-    budget_timeout = int(timeout_seconds or definition.budget.timeout_seconds)
+    budget_timeout = int(
+        definition.budget.timeout_seconds
+        if timeout_seconds is None
+        else timeout_seconds
+    )
     selected_models = _normalize_models(loop_name, models)
-    trial_limit = int(definition.budget.max_trials if max_trials is None else max_trials)
+    trial_limit = int(
+        definition.budget.max_trials if max_trials is None else max_trials
+    )
     if trial_limit <= 0:
         raise ValueError("--max-trials must be a positive integer.")
 
@@ -83,6 +89,7 @@ def run_autoresearch_loop(
         "profile": profile,
         "models": selected_models,
         "max_trials": trial_limit,
+        "max_trials_explicit": max_trials is not None,
         "timeout_seconds": budget_timeout,
         "dry_run": dry_run,
         "skip_plots": skip_plots,
@@ -96,7 +103,9 @@ def run_autoresearch_loop(
         return _run_classify_daytona(**common)
     if loop_name == "foundation-gpu-plan":
         return _run_foundation_gpu_plan(**common)
-    raise ValueError(f"Autoresearch loop '{loop_name}' is registered but has no runner.")
+    raise ValueError(
+        f"Autoresearch loop '{loop_name}' is registered but has no runner."
+    )
 
 
 def _run_forecast_daytona(**kwargs: Any) -> dict[str, Any]:
@@ -107,6 +116,7 @@ def _run_forecast_daytona(**kwargs: Any) -> dict[str, Any]:
     profile: str = kwargs["profile"]
     models: list[str] = kwargs["models"]
     max_trials: int = kwargs["max_trials"]
+    max_trials_explicit: bool = kwargs["max_trials_explicit"]
     timeout_seconds: int = kwargs["timeout_seconds"]
     dry_run: bool = kwargs["dry_run"]
     skip_plots: bool = kwargs["skip_plots"]
@@ -116,7 +126,7 @@ def _run_forecast_daytona(**kwargs: Any) -> dict[str, Any]:
     series_ids = _forecast_series_for_profile(profile)
     horizon = 18
     season_length = 12
-    rolling_origins = 1 if profile == "smoke" else 2
+    rolling_origins = _forecast_rolling_origins_for_profile(profile)
 
     warnings: list[str] = []
     if find_spec("statsforecast") is None:
@@ -126,9 +136,13 @@ def _run_forecast_daytona(**kwargs: Any) -> dict[str, Any]:
                 "statsforecast is not installed; skipping methods that require "
                 f"`ts-agents[forecasting]`: {', '.join(unavailable)}."
             )
-            models = [method for method in models if method not in _STATSFORECAST_METHODS]
+            models = [
+                method for method in models if method not in _STATSFORECAST_METHODS
+            ]
     if not models:
-        raise ImportError('No forecasting methods are available. Install "ts-agents[forecasting]".')
+        raise ImportError(
+            'No forecasting methods are available. Install "ts-agents[forecasting]".'
+        )
 
     trial_specs = _forecast_trial_specs(
         panel=panel,
@@ -137,16 +151,22 @@ def _run_forecast_daytona(**kwargs: Any) -> dict[str, Any]:
         rolling_origins=rolling_origins,
     )
     trial_pairs = _forecast_trial_pairs(trial_specs, models)
+    if profile == "full" and not max_trials_explicit:
+        max_trials = len(trial_pairs)
     scheduled_pairs = trial_pairs[:max_trials]
     trials: list[dict[str, Any]] = []
     start = time.monotonic()
 
     for trial_index, (spec, model) in enumerate(scheduled_pairs, start=1):
         if _budget_exhausted(start, timeout_seconds):
-            warnings.append(f"Stopped before trial {trial_index}; timeout budget exhausted.")
+            warnings.append(
+                f"Stopped before trial {trial_index}; timeout budget exhausted."
+            )
             break
         if dry_run:
-            trials.append(_planned_trial_row(run_id, trial_index, "forecasting", spec, model))
+            trials.append(
+                _planned_trial_row(run_id, trial_index, "forecasting", spec, model)
+            )
             continue
         trial_timeout = _trial_timeout_for_next(
             start,
@@ -169,8 +189,18 @@ def _run_forecast_daytona(**kwargs: Any) -> dict[str, Any]:
     ranking = _rank_forecast_trials(trials)
     warnings.extend(_forecast_ranking_warnings(trials))
     best_config = ranking[0] if ranking else {}
-    status = "degraded" if warnings or any(row.get("status") == "failed" for row in trials) else "ok"
-    plot_artifacts = [] if skip_plots or dry_run else _write_forecast_plot(output_path, trials)
+    status = (
+        "degraded"
+        if warnings or any(row.get("status") == "failed" for row in trials)
+        else "ok"
+    )
+    plot_artifacts = _write_optional_plot(
+        _write_forecast_plot,
+        output_path,
+        trials,
+        warnings,
+        enabled=not skip_plots and not dry_run,
+    )
     artifacts = _write_autoresearch_artifacts(
         output_path=output_path,
         loop_name="forecast-daytona",
@@ -243,7 +273,8 @@ def _run_classify_daytona(**kwargs: Any) -> dict[str, Any]:
         value_cols=["x", "y", "z"],
         label_col="label",
     )
-    window_sizes = [32, 64] if profile == "smoke" else list(DEFAULT_WINDOW_SIZES)
+    window_sizes = _classification_window_sizes_for_profile(profile)
+    n_splits = 5 if profile == "full" else 3
     trials: list[dict[str, Any]] = []
     warnings: list[str] = []
     start = time.monotonic()
@@ -256,10 +287,16 @@ def _run_classify_daytona(**kwargs: Any) -> dict[str, Any]:
             "window_sizes": window_sizes,
         }
         if _budget_exhausted(start, timeout_seconds):
-            warnings.append(f"Stopped before classifier {classifier}; timeout budget exhausted.")
+            warnings.append(
+                f"Stopped before classifier {classifier}; timeout budget exhausted."
+            )
             break
         if dry_run:
-            trials.append(_planned_trial_row(run_id, trial_index, "classification", spec, classifier))
+            trials.append(
+                _planned_trial_row(
+                    run_id, trial_index, "classification", spec, classifier
+                )
+            )
             continue
         trial_timeout = _trial_timeout_for_next(
             start,
@@ -276,14 +313,25 @@ def _run_classify_daytona(**kwargs: Any) -> dict[str, Any]:
                     stream_values=stream_input.values,
                     stream_labels=stream_input.labels,
                     window_sizes=window_sizes,
+                    n_splits=n_splits,
                     seed=seed,
                 )
             )
 
     ranking = _rank_classification_trials(trials)
     best_config = ranking[0] if ranking else {}
-    status = "degraded" if warnings or any(row.get("status") == "failed" for row in trials) else "ok"
-    plot_artifacts = [] if skip_plots or dry_run else _write_classification_plot(output_path, trials)
+    status = (
+        "degraded"
+        if warnings or any(row.get("status") == "failed" for row in trials)
+        else "ok"
+    )
+    plot_artifacts = _write_optional_plot(
+        _write_classification_plot,
+        output_path,
+        trials,
+        warnings,
+        enabled=not skip_plots and not dry_run,
+    )
     artifacts = list(dataset_artifacts)
     artifacts.extend(
         _write_autoresearch_artifacts(
@@ -303,7 +351,7 @@ def _run_classify_daytona(**kwargs: Any) -> dict[str, Any]:
                 "metric": "balanced_accuracy",
                 "balance": "segment_cap",
                 "max_windows_per_segment": 25,
-                "n_splits": 3,
+                "n_splits": n_splits,
                 "seed": seed,
             },
             trials=trials,
@@ -435,7 +483,13 @@ def _normalize_models(loop_name: str, models: Optional[Iterable[str]]) -> list[s
         if loop_name == "foundation-gpu-plan":
             return list(DEFAULT_FOUNDATION_MODELS)
         return []
-    normalized = [str(model).strip() for model in models if str(model).strip()]
+    normalized = []
+    for model in models:
+        if model is None:
+            raise ValueError(f"Model list for {loop_name} contains a null entry.")
+        value = str(model).strip()
+        if value:
+            normalized.append(value)
     if not normalized:
         return _normalize_models(loop_name, None)
     valid = {
@@ -446,7 +500,9 @@ def _normalize_models(loop_name: str, models: Optional[Iterable[str]]) -> list[s
     if valid is not None:
         invalid = sorted(set(normalized).difference(valid))
         if invalid:
-            raise ValueError(f"Unsupported model(s) for {loop_name}: {', '.join(invalid)}.")
+            raise ValueError(
+                f"Unsupported model(s) for {loop_name}: {', '.join(invalid)}."
+            )
     return normalized
 
 
@@ -476,6 +532,22 @@ def _forecast_series_for_profile(profile: str) -> list[str]:
     if profile == "smoke":
         return DEFAULT_FORECAST_SERIES[:1]
     return list(DEFAULT_FORECAST_SERIES)
+
+
+def _forecast_rolling_origins_for_profile(profile: str) -> int:
+    if profile == "smoke":
+        return 1
+    if profile == "full":
+        return 3
+    return 2
+
+
+def _classification_window_sizes_for_profile(profile: str) -> list[int]:
+    if profile == "smoke":
+        return [32, 64]
+    if profile == "full":
+        return [32, 64, 96, 128, 160, 192, 224]
+    return list(DEFAULT_WINDOW_SIZES)
 
 
 def _forecast_trial_specs(
@@ -684,6 +756,7 @@ def _evaluate_classifier_trial(
     stream_values: np.ndarray,
     stream_labels: np.ndarray,
     window_sizes: list[int],
+    n_splits: int,
     seed: int,
 ) -> dict[str, Any]:
     started = time.monotonic()
@@ -708,7 +781,7 @@ def _evaluate_classifier_trial(
             labeling="strict",
             balance="segment_cap",
             max_windows_per_segment=25,
-            n_splits=3,
+            n_splits=n_splits,
             test_size=0.25,
             seed=seed,
         )
@@ -721,7 +794,9 @@ def _evaluate_classifier_trial(
                 "balanced_accuracy": score,
                 "accuracy": None,
                 "f1_macro": None,
-                "n_windows": int(selection.n_windows_by_window.get(best_window_size, 0)),
+                "n_windows": int(
+                    selection.n_windows_by_window.get(best_window_size, 0)
+                ),
                 "effective_backend": classifier,
                 "evaluation_stage": "window_selection_cv",
                 "selection_scores_by_window": {
@@ -731,11 +806,13 @@ def _evaluate_classifier_trial(
             }
         )
     except Exception as exc:
-        row.update({
-            "status": "failed",
-            "error": str(exc),
-            "error_type": type(exc).__name__,
-        })
+        row.update(
+            {
+                "status": "failed",
+                "error": str(exc),
+                "error_type": type(exc).__name__,
+            }
+        )
     row["elapsed_seconds"] = round(time.monotonic() - started, 6)
     return row
 
@@ -816,9 +893,10 @@ def _rank_classification_trials(trials: list[dict[str, Any]]) -> list[dict[str, 
     return sorted(
         ranking,
         key=lambda row: (
-            -(row.get("balanced_accuracy") or 0.0),
-            row.get("best_window_size") or 0,
-            -(row.get("n_windows") or 0),
+            _sort_high_metric(row.get("balanced_accuracy")),
+            _sort_low_metric(row.get("best_window_size")),
+            _sort_high_metric(row.get("n_windows")),
+            str(row.get("model", "")),
         ),
     )
 
@@ -828,6 +906,14 @@ def _sort_low_metric(value: Any) -> float:
         number = float(value)
         if np.isfinite(number):
             return number
+    return float("inf")
+
+
+def _sort_high_metric(value: Any) -> float:
+    if isinstance(value, (int, float, np.integer, np.floating)):
+        number = float(value)
+        if np.isfinite(number):
+            return -number
     return float("inf")
 
 
@@ -1068,12 +1154,32 @@ def _trial_timeout(seconds: Optional[float]):
         signal.setitimer(signal.ITIMER_REAL, 0.0)
         signal.signal(signal.SIGALRM, previous_handler)
         if previous_timer[0] > 0:
-            remaining = max(0.001, previous_timer[0] - elapsed)
-            signal.setitimer(signal.ITIMER_REAL, remaining, previous_timer[1])
+            remaining = previous_timer[0] - elapsed
+            if remaining <= 0:
+                signal.raise_signal(signal.SIGALRM)
+            else:
+                signal.setitimer(signal.ITIMER_REAL, remaining, previous_timer[1])
 
 
 def _utc_now() -> str:
     return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _write_optional_plot(
+    plot_writer: Any,
+    output_path: Path,
+    trials: list[dict[str, Any]],
+    warnings: list[str],
+    *,
+    enabled: bool,
+) -> list[ArtifactRef]:
+    if not enabled:
+        return []
+    try:
+        return plot_writer(output_path, trials)
+    except Exception as exc:
+        warnings.append(f"Skipped ranking plot because {type(exc).__name__}: {exc}")
+        return []
 
 
 def _forecast_report(

--- a/ts_agents/autoresearch/runner.py
+++ b/ts_agents/autoresearch/runner.py
@@ -1,0 +1,1374 @@
+"""Execution logic for built-in autoresearch loops."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from datetime import datetime, timezone
+from importlib.util import find_spec
+import json
+from pathlib import Path
+import signal
+import stat
+import threading
+import time
+from typing import Any, Iterable, Optional
+
+import numpy as np
+import pandas as pd
+
+from ts_agents.cli.input_parsing import load_labeled_stream_input
+from ts_agents.cli.output import render_output, to_jsonable, write_output
+from ts_agents.contracts import ArtifactRef, CLI_SCHEMA_VERSION
+from ts_agents.runtime_paths import resolve_existing_path
+from ts_agents.workflows.common import (
+    WORKFLOW_MANIFEST_FILENAME,
+    artifact_ref,
+    clear_output_dir,
+    ensure_output_dir,
+    generate_workflow_run_id,
+    output_dir_has_files,
+)
+
+from .registry import get_loop, loop_to_dict
+
+
+DEFAULT_FORECAST_SERIES = ["M4", "M10", "M100", "M1000", "M1002"]
+DEFAULT_FORECAST_METHODS = ["seasonal_naive", "theta", "ets", "arima"]
+DEFAULT_CLASSIFIERS = ["knn", "minirocket", "rocket"]
+DEFAULT_FOUNDATION_MODELS = ["amazon/chronos-2", "amazon/chronos-t5-small", "AutonLab/MOMENT-1-large"]
+DEFAULT_WINDOW_SIZES = [32, 64, 96, 128, 160]
+_STATSFORECAST_METHODS = {"theta", "ets", "arima"}
+
+
+def run_autoresearch_loop(
+    *,
+    loop_name: str,
+    output_dir: str,
+    profile: str = "default",
+    models: Optional[Iterable[str]] = None,
+    max_trials: Optional[int] = None,
+    timeout_seconds: Optional[int] = None,
+    overwrite: bool = False,
+    dry_run: bool = False,
+    skip_plots: bool = False,
+    seed: int = 1337,
+    dataset: str = "auto",
+) -> dict[str, Any]:
+    """Run a built-in autoresearch loop and write reproducible artifacts."""
+    definition = get_loop(loop_name)
+    output_path = Path(output_dir).expanduser().resolve()
+    if output_dir_has_files(output_path):
+        if not overwrite:
+            raise ValueError(
+                "Autoresearch output directory already exists and is not empty. "
+                "Use --overwrite to replace prior artifacts."
+            )
+        clear_output_dir(output_path)
+    else:
+        ensure_output_dir(output_path)
+
+    started_at = _utc_now()
+    run_id = generate_workflow_run_id()
+    budget_timeout = int(timeout_seconds or definition.budget.timeout_seconds)
+    selected_models = _normalize_models(loop_name, models)
+    trial_limit = int(max_trials or definition.budget.max_trials)
+    if trial_limit <= 0:
+        raise ValueError("--max-trials must be a positive integer.")
+
+    common = {
+        "definition": definition,
+        "output_path": output_path,
+        "run_id": run_id,
+        "started_at": started_at,
+        "profile": profile,
+        "models": selected_models,
+        "max_trials": trial_limit,
+        "timeout_seconds": budget_timeout,
+        "dry_run": dry_run,
+        "skip_plots": skip_plots,
+        "seed": int(seed),
+        "dataset": dataset,
+    }
+
+    if loop_name == "forecast-daytona":
+        return _run_forecast_daytona(**common)
+    if loop_name == "classify-daytona":
+        return _run_classify_daytona(**common)
+    if loop_name == "foundation-gpu-plan":
+        return _run_foundation_gpu_plan(**common)
+    raise ValueError(f"Autoresearch loop '{loop_name}' is registered but has no runner.")
+
+
+def _run_forecast_daytona(**kwargs: Any) -> dict[str, Any]:
+    output_path: Path = kwargs["output_path"]
+    run_id: str = kwargs["run_id"]
+    definition = kwargs["definition"]
+    started_at: str = kwargs["started_at"]
+    profile: str = kwargs["profile"]
+    models: list[str] = kwargs["models"]
+    max_trials: int = kwargs["max_trials"]
+    timeout_seconds: int = kwargs["timeout_seconds"]
+    dry_run: bool = kwargs["dry_run"]
+    skip_plots: bool = kwargs["skip_plots"]
+
+    dataset_path = _resolve_runtime_file("data/m4_monthly_mini.csv")
+    panel = _load_m4_panel(dataset_path)
+    series_ids = _forecast_series_for_profile(profile)
+    horizon = 18
+    season_length = 12
+    rolling_origins = 1 if profile == "smoke" else 2
+
+    warnings: list[str] = []
+    if find_spec("statsforecast") is None:
+        unavailable = [method for method in models if method in _STATSFORECAST_METHODS]
+        if unavailable:
+            warnings.append(
+                "statsforecast is not installed; skipping methods that require "
+                f"`ts-agents[forecasting]`: {', '.join(unavailable)}."
+            )
+            models = [method for method in models if method not in _STATSFORECAST_METHODS]
+    if not models:
+        raise ImportError('No forecasting methods are available. Install "ts-agents[forecasting]".')
+
+    trial_specs = _forecast_trial_specs(
+        panel=panel,
+        series_ids=series_ids,
+        horizon=horizon,
+        rolling_origins=rolling_origins,
+    )
+    trial_pairs = _forecast_trial_pairs(trial_specs, models)
+    scheduled_pairs = trial_pairs[:max_trials]
+    trials: list[dict[str, Any]] = []
+    start = time.monotonic()
+
+    for trial_index, (spec, model) in enumerate(scheduled_pairs, start=1):
+        if _budget_exhausted(start, timeout_seconds):
+            warnings.append(f"Stopped before trial {trial_index}; timeout budget exhausted.")
+            break
+        if dry_run:
+            trials.append(_planned_trial_row(run_id, trial_index, "forecasting", spec, model))
+            continue
+        trial_timeout = _trial_timeout_for_next(
+            start,
+            timeout_seconds,
+            max_trials=max_trials,
+            completed_trials=len(trials),
+        )
+        with _trial_timeout(trial_timeout):
+            trials.append(
+                _evaluate_forecast_trial(
+                    run_id=run_id,
+                    trial_index=trial_index,
+                    spec=spec,
+                    model=model,
+                    horizon=horizon,
+                    season_length=season_length,
+                )
+            )
+
+    ranking = _rank_forecast_trials(trials)
+    warnings.extend(_forecast_ranking_warnings(trials))
+    best_config = ranking[0] if ranking else {}
+    status = "degraded" if warnings or any(row.get("status") == "failed" for row in trials) else "ok"
+    artifacts = _write_autoresearch_artifacts(
+        output_path=output_path,
+        loop_name="forecast-daytona",
+        run_id=run_id,
+        started_at=started_at,
+        definition=loop_to_dict(definition),
+        options={
+            "profile": profile,
+            "models": models,
+            "max_trials": max_trials,
+            "timeout_seconds": timeout_seconds,
+            "dry_run": dry_run,
+            "horizon": horizon,
+            "season_length": season_length,
+            "rolling_origins": rolling_origins,
+            "dataset": str(dataset_path),
+        },
+        trials=trials,
+        best_config=best_config,
+        report=_forecast_report(
+            dataset_path=dataset_path,
+            models=models,
+            trials=trials,
+            ranking=ranking,
+            dry_run=dry_run,
+        ),
+        extra_json={"model_ranking": ranking},
+        status=status,
+        warnings=warnings,
+    )
+    if not skip_plots and not dry_run:
+        artifacts.extend(_write_forecast_plot(output_path, trials))
+
+    return _result_payload(
+        loop_name="forecast-daytona",
+        run_id=run_id,
+        status=status,
+        summary=f"Forecast autoresearch loop completed with {len(trials)} model-trial rows.",
+        output_path=output_path,
+        trials=trials,
+        best_config=best_config,
+        artifacts=artifacts,
+        warnings=warnings,
+        started_at=started_at,
+        data_extra={"ranking": ranking, "dataset": str(dataset_path)},
+    )
+
+
+def _run_classify_daytona(**kwargs: Any) -> dict[str, Any]:
+    output_path: Path = kwargs["output_path"]
+    run_id: str = kwargs["run_id"]
+    definition = kwargs["definition"]
+    started_at: str = kwargs["started_at"]
+    profile: str = kwargs["profile"]
+    models: list[str] = kwargs["models"]
+    max_trials: int = kwargs["max_trials"]
+    timeout_seconds: int = kwargs["timeout_seconds"]
+    dry_run: bool = kwargs["dry_run"]
+    skip_plots: bool = kwargs["skip_plots"]
+    seed: int = kwargs["seed"]
+    dataset: str = kwargs["dataset"]
+
+    dataset_path, dataset_label, dataset_artifacts = _classification_dataset(
+        output_path=output_path,
+        dataset=dataset,
+        seed=seed,
+    )
+    stream_input = load_labeled_stream_input(
+        input_path=str(dataset_path),
+        time_col="timestamp",
+        value_cols=["x", "y", "z"],
+        label_col="label",
+    )
+    window_sizes = [32, 64] if profile == "smoke" else list(DEFAULT_WINDOW_SIZES)
+    trials: list[dict[str, Any]] = []
+    warnings: list[str] = []
+    start = time.monotonic()
+
+    scheduled_models = models[:max_trials]
+    for trial_index, classifier in enumerate(scheduled_models, start=1):
+        spec = {
+            "classifier": classifier,
+            "dataset": dataset_label,
+            "window_sizes": window_sizes,
+        }
+        if _budget_exhausted(start, timeout_seconds):
+            warnings.append(f"Stopped before classifier {classifier}; timeout budget exhausted.")
+            break
+        if dry_run:
+            trials.append(_planned_trial_row(run_id, trial_index, "classification", spec, classifier))
+            continue
+        trial_timeout = _trial_timeout_for_next(
+            start,
+            timeout_seconds,
+            max_trials=max_trials,
+            completed_trials=len(trials),
+        )
+        with _trial_timeout(trial_timeout):
+            trials.append(
+                _evaluate_classifier_trial(
+                    run_id=run_id,
+                    trial_index=trial_index,
+                    classifier=classifier,
+                    stream_values=stream_input.values,
+                    stream_labels=stream_input.labels,
+                    window_sizes=window_sizes,
+                    seed=seed,
+                )
+            )
+
+    ranking = _rank_classification_trials(trials)
+    best_config = ranking[0] if ranking else {}
+    status = "degraded" if warnings or any(row.get("status") == "failed" for row in trials) else "ok"
+    artifacts = list(dataset_artifacts)
+    artifacts.extend(
+        _write_autoresearch_artifacts(
+            output_path=output_path,
+            loop_name="classify-daytona",
+            run_id=run_id,
+            started_at=started_at,
+            definition=loop_to_dict(definition),
+            options={
+                "profile": profile,
+                "models": models,
+                "max_trials": max_trials,
+                "timeout_seconds": timeout_seconds,
+                "dry_run": dry_run,
+                "dataset": dataset_label,
+                "window_sizes": window_sizes,
+                "metric": "balanced_accuracy",
+                "balance": "segment_cap",
+                "max_windows_per_segment": 25,
+                "n_splits": 3,
+                "seed": seed,
+            },
+            trials=trials,
+            best_config=best_config,
+            report=_classification_report(
+                dataset_path=dataset_path,
+                models=models,
+                trials=trials,
+                ranking=ranking,
+                dry_run=dry_run,
+            ),
+            extra_json={"model_ranking": ranking},
+            status=status,
+            warnings=warnings,
+        )
+    )
+    if not skip_plots and not dry_run:
+        artifacts.extend(_write_classification_plot(output_path, trials))
+
+    return _result_payload(
+        loop_name="classify-daytona",
+        run_id=run_id,
+        status=status,
+        summary=f"Classification autoresearch loop completed with {len(trials)} trials.",
+        output_path=output_path,
+        trials=trials,
+        best_config=best_config,
+        artifacts=artifacts,
+        warnings=warnings,
+        started_at=started_at,
+        data_extra={"ranking": ranking, "dataset": str(dataset_path)},
+    )
+
+
+def _run_foundation_gpu_plan(**kwargs: Any) -> dict[str, Any]:
+    output_path: Path = kwargs["output_path"]
+    run_id: str = kwargs["run_id"]
+    definition = kwargs["definition"]
+    started_at: str = kwargs["started_at"]
+    profile: str = kwargs["profile"]
+    models: list[str] = kwargs["models"]
+    max_trials: int = kwargs["max_trials"]
+    timeout_seconds: int = kwargs["timeout_seconds"]
+
+    plan = _foundation_gpu_plan(
+        run_id=run_id,
+        profile=profile,
+        models=models,
+        max_trials=max_trials,
+        timeout_seconds=timeout_seconds,
+    )
+    chronos_config = _chronos_config_yaml(plan)
+    moment_config = _moment_config_yaml(plan)
+    commands = _foundation_commands(plan)
+    report = _foundation_report(plan)
+
+    artifacts = [
+        _write_json(output_path / "foundation_gpu_plan.json", plan, "Foundation-model plan."),
+        _write_text(
+            output_path / "chronos_finetune_config.yaml",
+            chronos_config,
+            "Chronos fine-tuning config template.",
+            mime_type="text/yaml",
+        ),
+        _write_text(
+            output_path / "moment_classification_config.yaml",
+            moment_config,
+            "MOMENT classification fine-tuning config template.",
+            mime_type="text/yaml",
+        ),
+        _write_text(
+            output_path / "commands.sh",
+            commands,
+            "Plan-only GPU setup notes and validation commands.",
+            mime_type="text/x-shellscript",
+        ),
+        _write_text(output_path / "report.md", report, "Foundation GPU plan report."),
+    ]
+    commands_path = output_path / "commands.sh"
+    commands_path.chmod(commands_path.stat().st_mode | stat.S_IXUSR)
+
+    best_config: dict[str, Any] = {}
+    manifest = _manifest_payload(
+        loop_name="foundation-gpu-plan",
+        run_id=run_id,
+        status="plan-only",
+        summary="Foundation GPU plan materialized; no model training or evaluation was run.",
+        output_path=output_path,
+        started_at=started_at,
+        definition=loop_to_dict(definition),
+        options={
+            "profile": profile,
+            "models": models,
+            "max_trials": max_trials,
+            "timeout_seconds": timeout_seconds,
+            "gpu": "RTX PRO 6000 Blackwell",
+            "plan_only": True,
+        },
+        artifacts=artifacts,
+        warnings=[],
+        best_config=best_config,
+    )
+    artifacts.append(_write_json(output_path / WORKFLOW_MANIFEST_FILENAME, manifest, "Autoresearch run manifest."))
+
+    return _result_payload(
+        loop_name="foundation-gpu-plan",
+        run_id=run_id,
+        status="plan-only",
+        summary="Foundation GPU plan materialized; no model training or evaluation was run.",
+        output_path=output_path,
+        trials=[],
+        best_config=best_config,
+        artifacts=artifacts,
+        warnings=[],
+        started_at=started_at,
+        data_extra={
+            "plan": plan,
+            "plan_only": True,
+            "recommended_runs": plan["recommended_runs"],
+            "quality_flags": ["plan_only"],
+        },
+    )
+
+def _normalize_models(loop_name: str, models: Optional[Iterable[str]]) -> list[str]:
+    if models is None:
+        if loop_name == "forecast-daytona":
+            return list(DEFAULT_FORECAST_METHODS)
+        if loop_name == "classify-daytona":
+            return list(DEFAULT_CLASSIFIERS)
+        if loop_name == "foundation-gpu-plan":
+            return list(DEFAULT_FOUNDATION_MODELS)
+        return []
+    normalized = [str(model).strip() for model in models if str(model).strip()]
+    if not normalized:
+        return _normalize_models(loop_name, None)
+    valid = {
+        "forecast-daytona": set(DEFAULT_FORECAST_METHODS),
+        "classify-daytona": set(DEFAULT_CLASSIFIERS),
+        "foundation-gpu-plan": set(DEFAULT_FOUNDATION_MODELS),
+    }.get(loop_name)
+    if valid is not None:
+        invalid = sorted(set(normalized).difference(valid))
+        if invalid:
+            raise ValueError(f"Unsupported model(s) for {loop_name}: {', '.join(invalid)}.")
+    return normalized
+
+
+def _resolve_runtime_file(relative_path: str) -> Path:
+    resolved = resolve_existing_path(relative_path)
+    path = resolved if resolved is not None else Path(relative_path)
+    if not path.exists():
+        raise FileNotFoundError(f"Required autoresearch dataset not found: {relative_path}")
+    return path.resolve()
+
+
+def _load_m4_panel(dataset_path: Path) -> dict[str, dict[str, np.ndarray]]:
+    df = pd.read_csv(dataset_path)
+    required = {"unique_id", "split", "ds", "y"}
+    missing = sorted(required.difference(df.columns))
+    if missing:
+        raise ValueError(f"{dataset_path} is missing required columns: {missing}")
+    panel: dict[str, dict[str, np.ndarray]] = {}
+    for series_id, series_df in df.sort_values(["unique_id", "ds"]).groupby("unique_id"):
+        train = series_df[series_df["split"] == "train"]["y"].to_numpy(dtype=float)
+        holdout = series_df[series_df["split"] == "holdout"]["y"].to_numpy(dtype=float)
+        panel[str(series_id)] = {"train": train, "holdout": holdout}
+    return panel
+
+
+def _forecast_series_for_profile(profile: str) -> list[str]:
+    if profile == "smoke":
+        return DEFAULT_FORECAST_SERIES[:1]
+    return list(DEFAULT_FORECAST_SERIES)
+
+
+def _forecast_trial_specs(
+    *,
+    panel: dict[str, dict[str, np.ndarray]],
+    series_ids: list[str],
+    horizon: int,
+    rolling_origins: int,
+) -> list[dict[str, Any]]:
+    specs: list[dict[str, Any]] = []
+    for series_id in series_ids:
+        if series_id not in panel:
+            continue
+        train = panel[series_id]["train"]
+        holdout = panel[series_id]["holdout"]
+        for origin_index, origin in enumerate(_rolling_origins(len(train), horizon, rolling_origins), start=1):
+            specs.append(
+                {
+                    "series_id": series_id,
+                    "phase": f"rolling_origin_{origin_index}",
+                    "origin": int(origin),
+                    "train": train[:origin],
+                    "actual": train[origin:origin + horizon],
+                }
+            )
+        specs.append(
+            {
+                "series_id": series_id,
+                "phase": "holdout",
+                "origin": int(len(train)),
+                "train": train,
+                "actual": holdout[:horizon],
+            }
+        )
+    return specs
+
+
+def _rolling_origins(train_length: int, horizon: int, n_origins: int) -> list[int]:
+    if n_origins <= 0 or train_length < horizon * 2:
+        return []
+    latest_origin = train_length - horizon
+    first_origin = latest_origin - horizon * (n_origins - 1)
+    origins = [first_origin + i * horizon for i in range(n_origins)]
+    return [
+        int(origin)
+        for origin in origins
+        if origin >= horizon and origin + horizon <= train_length
+    ]
+
+
+def _forecast_trial_pairs(
+    trial_specs: list[dict[str, Any]],
+    models: list[str],
+) -> list[tuple[dict[str, Any], str]]:
+    return [(spec, model) for spec in trial_specs for model in models]
+
+
+def _evaluate_forecast_trial(
+    *,
+    run_id: str,
+    trial_index: int,
+    spec: dict[str, Any],
+    model: str,
+    horizon: int,
+    season_length: int,
+) -> dict[str, Any]:
+    actual = np.asarray(spec["actual"], dtype=float)
+    started = time.monotonic()
+    row = {
+        "run_id": run_id,
+        "trial_id": f"forecast-{trial_index:03d}-{model}",
+        "trial_index": trial_index,
+        "task": "forecasting",
+        "dataset": "m4_monthly_mini",
+        "series_id": spec["series_id"],
+        "phase": spec["phase"],
+        "origin": spec["origin"],
+        "model": model,
+    }
+    try:
+        forecast = _forecast_with_method(
+            model,
+            np.asarray(spec["train"], dtype=float),
+            horizon=horizon,
+            season_length=season_length,
+        )[: len(actual)]
+        metrics = _forecast_metrics(actual, forecast)
+        row.update(metrics)
+        row["status"] = "ok"
+    except Exception as exc:
+        row.update({
+            "status": "failed",
+            "error": str(exc),
+            "error_type": type(exc).__name__,
+        })
+    row["elapsed_seconds"] = round(time.monotonic() - started, 6)
+    return row
+
+
+def _forecast_with_method(method: str, series: np.ndarray, *, horizon: int, season_length: int) -> np.ndarray:
+    from ts_agents.core.forecasting import (
+        forecast_arima,
+        forecast_ets,
+        forecast_seasonal_naive,
+        forecast_theta,
+    )
+
+    func_map = {
+        "seasonal_naive": forecast_seasonal_naive,
+        "theta": forecast_theta,
+        "ets": forecast_ets,
+        "arima": forecast_arima,
+    }
+    return np.asarray(
+        func_map[method](series, horizon=horizon, season_length=season_length).forecast,
+        dtype=float,
+    )
+
+
+def _forecast_metrics(actual: np.ndarray, forecast: np.ndarray) -> dict[str, float]:
+    errors = actual - forecast
+    denominator = np.abs(actual) + np.abs(forecast)
+    smape_values = np.divide(
+        200.0 * np.abs(errors),
+        denominator,
+        out=np.zeros_like(denominator, dtype=float),
+        where=denominator != 0,
+    )
+    nonzero = actual != 0
+    mape = (
+        float(np.mean(np.abs(errors[nonzero] / actual[nonzero])) * 100.0)
+        if np.any(nonzero)
+        else float("nan")
+    )
+    return {
+        "smape": float(np.mean(smape_values)),
+        "mae": float(np.mean(np.abs(errors))),
+        "rmse": float(np.sqrt(np.mean(errors ** 2))),
+        "mape": mape,
+    }
+
+
+def _classification_dataset(
+    *,
+    output_path: Path,
+    dataset: str,
+    seed: int,
+) -> tuple[Path, str, list[ArtifactRef]]:
+    if dataset == "synthetic":
+        return _write_synthetic_classification_dataset(output_path, seed)
+    wisdm = resolve_existing_path("data/wisdm_subset.csv")
+    if dataset in {"auto", "wisdm_subset"} and wisdm is not None and wisdm.exists():
+        return wisdm.resolve(), "wisdm_subset", []
+    return _write_synthetic_classification_dataset(output_path, seed)
+
+
+def _write_synthetic_classification_dataset(output_path: Path, seed: int) -> tuple[Path, str, list[ArtifactRef]]:
+    rng = np.random.default_rng(seed)
+    rows: list[dict[str, Any]] = []
+    timestamp = 0
+    specs = [
+        ("idle", 5, 0.05, 0.0),
+        ("walk", 5, 0.15, 1.6),
+        ("jog", 5, 0.22, 2.8),
+    ]
+    for repeat in range(8):
+        for label, seconds, noise, freq in specs:
+            n = seconds * 20
+            t = np.arange(n) / 20.0
+            if label == "idle":
+                values = rng.normal(0.0, noise, size=(n, 3))
+            else:
+                phase = rng.uniform(0.0, 2 * np.pi, size=3)
+                amp = 1.0 if label == "walk" else 1.8
+                values = np.column_stack(
+                    [
+                        amp * np.sin(2 * np.pi * freq * t + phase[0]),
+                        0.8 * amp * np.sin(2 * np.pi * freq * t + phase[1]),
+                        0.6 * amp * np.sin(2 * np.pi * freq * t + phase[2]),
+                    ]
+                )
+                values += rng.normal(0.0, noise, size=values.shape)
+            for x, y, z in values:
+                rows.append({"timestamp": timestamp, "x": x, "y": y, "z": z, "label": label})
+                timestamp += 1
+    path = output_path / "synthetic_labeled_stream.csv"
+    pd.DataFrame(rows).to_csv(path, index=False)
+    return (
+        path.resolve(),
+        "synthetic_gait",
+        [artifact_ref(
+            kind="csv",
+            path=path,
+            mime_type="text/csv",
+            description="Generated synthetic labeled stream used for classification.",
+            created_by="classify-daytona",
+        )],
+    )
+
+
+def _evaluate_classifier_trial(
+    *,
+    run_id: str,
+    trial_index: int,
+    classifier: str,
+    stream_values: np.ndarray,
+    stream_labels: np.ndarray,
+    window_sizes: list[int],
+    seed: int,
+) -> dict[str, Any]:
+    started = time.monotonic()
+    row: dict[str, Any] = {
+        "run_id": run_id,
+        "trial_id": f"classify-{trial_index:03d}-{classifier}",
+        "trial_index": trial_index,
+        "task": "classification",
+        "dataset": "labeled_activity_stream",
+        "model": classifier,
+        "classifier": classifier,
+    }
+    try:
+        from ts_agents.core.windowing import select_window_size
+
+        selection = select_window_size(
+            stream_values,
+            stream_labels,
+            window_sizes=window_sizes,
+            metric="balanced_accuracy",
+            classifier=classifier,
+            labeling="strict",
+            balance="segment_cap",
+            max_windows_per_segment=25,
+            n_splits=3,
+            test_size=0.25,
+            seed=seed,
+        )
+        best_window_size = int(selection.best_window_size)
+        score = _as_optional_float(selection.scores_by_window.get(best_window_size))
+        row.update(
+            {
+                "status": "ok",
+                "best_window_size": best_window_size,
+                "balanced_accuracy": score,
+                "accuracy": None,
+                "f1_macro": None,
+                "n_windows": int(selection.n_windows_by_window.get(best_window_size, 0)),
+                "effective_backend": classifier,
+                "evaluation_stage": "window_selection_cv",
+                "selection_scores_by_window": {
+                    str(window): _as_optional_float(value)
+                    for window, value in selection.scores_by_window.items()
+                },
+            }
+        )
+    except Exception as exc:
+        row.update({
+            "status": "failed",
+            "error": str(exc),
+            "error_type": type(exc).__name__,
+        })
+    row["elapsed_seconds"] = round(time.monotonic() - started, 6)
+    return row
+
+
+def _as_optional_float(value: Any) -> Optional[float]:
+    if isinstance(value, (int, float, np.integer, np.floating)):
+        number = float(value)
+        return number if np.isfinite(number) else None
+    return None
+
+
+def _rank_forecast_trials(trials: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    ok = [row for row in trials if row.get("status") == "ok"]
+    by_model: dict[str, list[dict[str, Any]]] = {}
+    for row in ok:
+        by_model.setdefault(str(row["model"]), []).append(row)
+    ranking = []
+    for model, rows in by_model.items():
+        holdout_rows = [row for row in rows if row.get("phase") == "holdout"]
+        rolling_rows = [row for row in rows if str(row.get("phase", "")).startswith("rolling_origin_")]
+        ranking.append(
+            {
+                "model": model,
+                "primary_metric": "smape",
+                "smape": _mean_metric(rows, "smape"),
+                "holdout_smape": _mean_metric(holdout_rows, "smape"),
+                "rolling_smape": _mean_metric(rolling_rows, "smape"),
+                "mae": _mean_metric(rows, "mae"),
+                "rmse": _mean_metric(rows, "rmse"),
+                "n_trials": len(rows),
+                "n_holdout_trials": len(holdout_rows),
+                "n_rolling_trials": len(rolling_rows),
+            }
+        )
+    return sorted(ranking, key=lambda row: (row["smape"], row["mae"], row["rmse"]))
+
+
+def _forecast_ranking_warnings(trials: list[dict[str, Any]]) -> list[str]:
+    ok = [row for row in trials if row.get("status") == "ok"]
+    if not ok:
+        return []
+    warnings: list[str] = []
+    if not any(row.get("phase") == "holdout" for row in ok):
+        warnings.append("Forecast ranking has no successful holdout rows; ranking uses rolling-origin rows only.")
+    counts: dict[str, int] = {}
+    for row in ok:
+        counts[str(row.get("model"))] = counts.get(str(row.get("model")), 0) + 1
+    if len(set(counts.values())) > 1:
+        warnings.append(
+            "Forecast ranking is based on an unequal number of successful rows per model: "
+            + ", ".join(f"{model}={count}" for model, count in sorted(counts.items()))
+            + "."
+        )
+    return warnings
+
+
+def _rank_classification_trials(trials: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    ok = [row for row in trials if row.get("status") == "ok"]
+    ranking = [
+        {
+            "model": row["model"],
+            "primary_metric": "balanced_accuracy",
+            "balanced_accuracy": row.get("balanced_accuracy"),
+            "best_window_size": row.get("best_window_size"),
+            "n_windows": row.get("n_windows"),
+            "n_trials": 1,
+        }
+        for row in ok
+    ]
+    return sorted(
+        ranking,
+        key=lambda row: (
+            -(row.get("balanced_accuracy") or 0.0),
+            row.get("best_window_size") or 0,
+            -(row.get("n_windows") or 0),
+        ),
+    )
+
+
+def _mean_metric(rows: list[dict[str, Any]], key: str) -> float:
+    values = [float(row[key]) for row in rows if isinstance(row.get(key), (int, float))]
+    return float(np.mean(values)) if values else float("nan")
+
+
+def _write_autoresearch_artifacts(
+    *,
+    output_path: Path,
+    loop_name: str,
+    run_id: str,
+    started_at: str,
+    definition: dict[str, Any],
+    options: dict[str, Any],
+    trials: list[dict[str, Any]],
+    best_config: dict[str, Any],
+    report: str,
+    extra_json: Optional[dict[str, Any]] = None,
+    status: str = "ok",
+    warnings: Optional[list[str]] = None,
+) -> list[ArtifactRef]:
+    trials_df = pd.DataFrame(trials)
+    artifacts = [
+        _write_csv(output_path / "trials.csv", trials_df, "Autoresearch trial table."),
+        _write_jsonl(output_path / "trials.jsonl", trials, "Autoresearch trial records."),
+        _write_json(output_path / "best_config.json", best_config, "Best autoresearch configuration."),
+        _write_text(output_path / "report.md", report, "Autoresearch markdown report."),
+    ]
+    if extra_json:
+        artifacts.append(_write_json(output_path / "summary.json", extra_json, "Autoresearch loop summary."))
+    manifest = _manifest_payload(
+        loop_name=loop_name,
+        run_id=run_id,
+        status=status,
+        summary=f"{loop_name} autoresearch artifacts.",
+        output_path=output_path,
+        started_at=started_at,
+        definition=definition,
+        options=options,
+        artifacts=artifacts,
+        warnings=warnings or [],
+        best_config=best_config,
+    )
+    artifacts.append(_write_json(output_path / WORKFLOW_MANIFEST_FILENAME, manifest, "Autoresearch run manifest."))
+    return artifacts
+
+
+def _write_json(path: Path, data: Any, description: str) -> ArtifactRef:
+    payload = render_output(to_jsonable(data), json_output=True)
+    write_output(payload, str(path))
+    return artifact_ref(
+        kind="json",
+        path=path,
+        mime_type="application/json",
+        description=description,
+        created_by="autoresearch",
+    )
+
+
+def _write_jsonl(path: Path, rows: list[dict[str, Any]], description: str) -> ArtifactRef:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    content = "\n".join(json.dumps(to_jsonable(row), sort_keys=True) for row in rows)
+    path.write_text(content + ("\n" if content else ""), encoding="utf-8")
+    return artifact_ref(
+        kind="jsonl",
+        path=path,
+        mime_type="application/x-jsonlines",
+        description=description,
+        created_by="autoresearch",
+    )
+
+
+def _write_csv(path: Path, dataframe: pd.DataFrame, description: str) -> ArtifactRef:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    dataframe.to_csv(path, index=False)
+    return artifact_ref(
+        kind="csv",
+        path=path,
+        mime_type="text/csv",
+        description=description,
+        created_by="autoresearch",
+    )
+
+
+def _write_text(path: Path, content: str, description: str, *, mime_type: str = "text/markdown") -> ArtifactRef:
+    write_output(content, str(path))
+    return artifact_ref(
+        kind="markdown" if mime_type == "text/markdown" else "text",
+        path=path,
+        mime_type=mime_type,
+        description=description,
+        created_by="autoresearch",
+    )
+
+
+def _manifest_payload(
+    *,
+    loop_name: str,
+    run_id: str,
+    status: str,
+    summary: str,
+    output_path: Path,
+    started_at: str,
+    definition: dict[str, Any],
+    options: dict[str, Any],
+    artifacts: list[ArtifactRef],
+    warnings: list[str],
+    best_config: dict[str, Any],
+) -> dict[str, Any]:
+    return {
+        "schema_version": CLI_SCHEMA_VERSION,
+        "kind": "autoresearch_run",
+        "loop": loop_name,
+        "run_id": run_id,
+        "status": status,
+        "summary": summary,
+        "created_at": started_at,
+        "output_dir": str(output_path),
+        "manifest_path": str(output_path / WORKFLOW_MANIFEST_FILENAME),
+        "definition": definition,
+        "options": to_jsonable(options),
+        "best_config": to_jsonable(best_config),
+        "warnings": to_jsonable(warnings),
+        "artifacts": [to_jsonable(artifact) for artifact in artifacts],
+    }
+
+
+def _result_payload(
+    *,
+    loop_name: str,
+    run_id: str,
+    status: str,
+    summary: str,
+    output_path: Path,
+    trials: list[dict[str, Any]],
+    best_config: dict[str, Any],
+    artifacts: list[ArtifactRef],
+    warnings: list[str],
+    started_at: str,
+    data_extra: Optional[dict[str, Any]] = None,
+) -> dict[str, Any]:
+    data = {
+        "loop": loop_name,
+        "run_id": run_id,
+        "output_dir": str(output_path),
+        "manifest_path": str(output_path / WORKFLOW_MANIFEST_FILENAME),
+        "started_at": started_at,
+        "trial_count": len(trials),
+        "best_config": best_config,
+        "quality_flags": [],
+    }
+    if data_extra:
+        data.update(data_extra)
+    return {
+        "kind": "autoresearch",
+        "summary": summary,
+        "status": status,
+        "data": data,
+        "artifacts": artifacts,
+        "warnings": warnings,
+    }
+
+
+def _planned_trial_row(
+    run_id: str,
+    trial_index: int,
+    task: str,
+    spec: dict[str, Any],
+    model: str,
+) -> dict[str, Any]:
+    return {
+        "run_id": run_id,
+        "trial_id": f"{task}-{trial_index:03d}-{model}",
+        "trial_index": trial_index,
+        "task": task,
+        "model": model,
+        "status": "planned",
+        "spec": to_jsonable({k: v for k, v in spec.items() if k not in {"train", "actual"}}),
+    }
+
+
+def _budget_exhausted(start: float, timeout_seconds: int) -> bool:
+    return timeout_seconds > 0 and (time.monotonic() - start) >= timeout_seconds
+
+
+def _trial_timeout_for_next(
+    start: float,
+    timeout_seconds: int,
+    *,
+    max_trials: int,
+    completed_trials: int,
+) -> Optional[float]:
+    if timeout_seconds <= 0:
+        return None
+    remaining = timeout_seconds - (time.monotonic() - start)
+    if remaining <= 0:
+        return 0.001
+    nominal = timeout_seconds / max(1, max_trials)
+    per_trial_cap = max(30.0, nominal * 2.0)
+    return max(0.001, min(remaining, per_trial_cap))
+
+
+@contextmanager
+def _trial_timeout(seconds: Optional[float]):
+    if (
+        seconds is None
+        or seconds <= 0
+        or threading.current_thread() is not threading.main_thread()
+        or not hasattr(signal, "SIGALRM")
+        or not hasattr(signal, "ITIMER_REAL")
+    ):
+        yield
+        return
+
+    def _raise_timeout(_signum: int, _frame: Any) -> None:
+        raise TimeoutError(f"Trial exceeded {seconds:.1f}s wall-clock limit.")
+
+    previous_handler = signal.getsignal(signal.SIGALRM)
+    previous_timer = signal.getitimer(signal.ITIMER_REAL)
+    signal.signal(signal.SIGALRM, _raise_timeout)
+    signal.setitimer(signal.ITIMER_REAL, float(seconds))
+    try:
+        yield
+    finally:
+        signal.setitimer(signal.ITIMER_REAL, 0.0)
+        signal.signal(signal.SIGALRM, previous_handler)
+        if previous_timer[0] > 0:
+            signal.setitimer(signal.ITIMER_REAL, previous_timer[0], previous_timer[1])
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _forecast_report(
+    *,
+    dataset_path: Path,
+    models: list[str],
+    trials: list[dict[str, Any]],
+    ranking: list[dict[str, Any]],
+    dry_run: bool,
+) -> str:
+    lines = [
+        "# Forecast Daytona Autoresearch",
+        "",
+        f"- dataset: `{dataset_path}`",
+        f"- models: `{', '.join(models)}`",
+        f"- mode: `{'dry-run' if dry_run else 'executed'}`",
+        "- primary metric: `sMAPE` (lower is better)",
+        "",
+        "## Ranking",
+        "",
+    ]
+    if ranking:
+        lines.extend(_markdown_table(ranking, ["model", "smape", "mae", "rmse", "n_trials"]))
+    else:
+        lines.append("No completed model trials were available for ranking.")
+    lines.extend(["", "## Trial Count", "", f"- rows: `{len(trials)}`", ""])
+    return "\n".join(lines)
+
+
+def _classification_report(
+    *,
+    dataset_path: Path,
+    models: list[str],
+    trials: list[dict[str, Any]],
+    ranking: list[dict[str, Any]],
+    dry_run: bool,
+) -> str:
+    lines = [
+        "# Classification Daytona Autoresearch",
+        "",
+        f"- dataset: `{dataset_path}`",
+        f"- classifiers: `{', '.join(models)}`",
+        f"- mode: `{'dry-run' if dry_run else 'executed'}`",
+        "- primary metric: `balanced_accuracy` (higher is better)",
+        "",
+        "## Ranking",
+        "",
+    ]
+    if ranking:
+        lines.extend(_markdown_table(ranking, ["model", "balanced_accuracy", "best_window_size", "n_windows"]))
+    else:
+        lines.append("No completed classifier trials were available for ranking.")
+    lines.extend(["", "## Trial Count", "", f"- rows: `{len(trials)}`", ""])
+    return "\n".join(lines)
+
+
+def _markdown_table(rows: list[dict[str, Any]], columns: list[str]) -> list[str]:
+    lines = ["| " + " | ".join(columns) + " |", "| " + " | ".join(["---"] * len(columns)) + " |"]
+    for row in rows:
+        values = []
+        for column in columns:
+            value = row.get(column)
+            if isinstance(value, float):
+                values.append(f"{value:.4f}")
+            else:
+                values.append("" if value is None else str(value))
+        lines.append("| " + " | ".join(values) + " |")
+    return lines
+
+
+def _write_forecast_plot(output_path: Path, trials: list[dict[str, Any]]) -> list[ArtifactRef]:
+    ok = [row for row in trials if row.get("status") == "ok" and isinstance(row.get("smape"), (int, float))]
+    if not ok:
+        return []
+    try:
+        import matplotlib.pyplot as plt
+    except ImportError:
+        return []
+    df = pd.DataFrame(ok)
+    summary = df.groupby("model", as_index=False)["smape"].mean().sort_values("smape")
+    fig, ax = plt.subplots(figsize=(8, 4))
+    ax.bar(summary["model"], summary["smape"])
+    ax.set_ylabel("mean sMAPE")
+    ax.set_title("Forecast autoresearch ranking")
+    fig.tight_layout()
+    path = output_path / "ranking.png"
+    fig.savefig(path, dpi=150)
+    plt.close(fig)
+    return [artifact_ref(kind="image", path=path, mime_type="image/png", description="Forecast ranking plot.", created_by="autoresearch")]
+
+
+def _write_classification_plot(output_path: Path, trials: list[dict[str, Any]]) -> list[ArtifactRef]:
+    ok = [row for row in trials if row.get("status") == "ok" and isinstance(row.get("balanced_accuracy"), (int, float))]
+    if not ok:
+        return []
+    try:
+        import matplotlib.pyplot as plt
+    except ImportError:
+        return []
+    df = pd.DataFrame(ok).sort_values("balanced_accuracy", ascending=False)
+    fig, ax = plt.subplots(figsize=(8, 4))
+    ax.bar(df["model"], df["balanced_accuracy"])
+    ax.set_ylabel("balanced accuracy")
+    ax.set_title("Classification autoresearch ranking")
+    fig.tight_layout()
+    path = output_path / "ranking.png"
+    fig.savefig(path, dpi=150)
+    plt.close(fig)
+    return [artifact_ref(kind="image", path=path, mime_type="image/png", description="Classification ranking plot.", created_by="autoresearch")]
+
+
+def _foundation_gpu_plan(
+    *,
+    run_id: str,
+    profile: str,
+    models: list[str],
+    max_trials: int,
+    timeout_seconds: int,
+) -> dict[str, Any]:
+    model_revisions = {
+        "amazon/chronos-2": "254b5357164a84326913b0695216f690752ac55d",
+        "amazon/chronos-t5-small": "4753ebecb99f65f84cd2823c56f7ab22b02ac303",
+        "AutonLab/MOMENT-1-large": "3582f9d7f033eea9d43e6a802ba0e36d5f26b57c",
+    }
+    recommended_runs = []
+    if "amazon/chronos-2" in models:
+        recommended_runs.append(
+            {
+                "task": "forecasting",
+                "model": "amazon/chronos-2",
+                "revision": model_revisions["amazon/chronos-2"],
+                "mode": "zero_shot_evaluation",
+                "primary_metric": "sMAPE",
+            }
+        )
+    if "amazon/chronos-t5-small" in models:
+        recommended_runs.append(
+            {
+                "task": "forecasting",
+                "model": "amazon/chronos-t5-small",
+                "revision": model_revisions["amazon/chronos-t5-small"],
+                "mode": "fine_tune_fallback_after_adapter",
+                "primary_metric": "sMAPE",
+            }
+        )
+    if "AutonLab/MOMENT-1-large" in models:
+        recommended_runs.append(
+            {
+                "task": "classification",
+                "model": "AutonLab/MOMENT-1-large",
+                "revision": model_revisions["AutonLab/MOMENT-1-large"],
+                "mode": "linear_probe_then_peft_after_adapter",
+                "primary_metric": "balanced_accuracy",
+            }
+        )
+
+    return {
+        "run_id": run_id,
+        "profile": profile,
+        "status": "plan-only",
+        "plan_only": True,
+        "target_hardware": "1x RTX PRO 6000 Blackwell",
+        "selected_models": models,
+        "model_revisions": model_revisions,
+        "budget": {
+            "timeout_seconds": timeout_seconds,
+            "max_trials": max_trials,
+            "smoke": {"minutes": 30, "seeds": [1337], "max_steps": 1000},
+            "full": {"hours": 4, "seeds": [1337, 2027, 9001], "checkpoint_cap_gb": 5},
+        },
+        "forecasting": {
+            "primary_model": "amazon/chronos-2",
+            "primary_model_revision": model_revisions["amazon/chronos-2"],
+            "finetune_model": "amazon/chronos-t5-small",
+            "finetune_model_revision": model_revisions["amazon/chronos-t5-small"],
+            "package": "chronos-forecasting>=2.0,<3",
+            "dataset": "data/m4_monthly_mini.csv; adapter must create GluonTS Arrow before fine-tuning",
+            "metrics": ["sMAPE", "MASE", "MAE", "RMSE"],
+            "source": "https://github.com/amazon-science/chronos-forecasting",
+        },
+        "classification": {
+            "primary_model": "AutonLab/MOMENT-1-large",
+            "primary_model_revision": model_revisions["AutonLab/MOMENT-1-large"],
+            "package": "momentfm",
+            "dataset": "generated/vendored labeled stream; adapter must create windowed_activity_dataset.npz",
+            "metrics": ["balanced_accuracy", "macro_f1", "accuracy"],
+            "source": "https://github.com/moment-timeseries-foundation-model/moment",
+        },
+        "adapter_requirements": [
+            "Create m4_monthly_mini.arrow before Chronos fine-tuning.",
+            "Create windowed_activity_dataset.npz before MOMENT classification fine-tuning.",
+            "Pin package versions in the training environment lockfile before running fine-tuning.",
+        ],
+        "recommended_runs": recommended_runs,
+    }
+
+
+def _chronos_config_yaml(plan: dict[str, Any]) -> str:
+    return "\n".join(
+        [
+            "# Chronos fine-tuning template for ts-agents foundation-gpu-plan",
+            "# Plan-only artifact: adapter outputs must be materialized before use.",
+            "model_id: amazon/chronos-t5-small",
+            f"model_revision: {plan['model_revisions']['amazon/chronos-t5-small']}",
+            "random_init: false",
+            "tokenizer_type: mean_scale_uniform_bins",
+            "context_length: 512",
+            "prediction_length: 18",
+            "max_steps: 1000",
+            "learning_rate: 0.001",
+            "per_device_train_batch_size: 32",
+            "torch_compile: false",
+            "output_dir: outputs/autoresearch/foundation-gpu-plan/chronos",
+            "training_data_paths: []",
+            "validation_data_paths: []",
+            "probability: []",
+            "adapter_required: true",
+            f"source: {plan['forecasting']['source']}",
+            "",
+        ]
+    )
+
+
+def _moment_config_yaml(plan: dict[str, Any]) -> str:
+    return "\n".join(
+        [
+            "# MOMENT classification fine-tuning template for ts-agents foundation-gpu-plan",
+            "# Plan-only artifact: adapter outputs must be materialized before use.",
+            "model_id: AutonLab/MOMENT-1-large",
+            f"model_revision: {plan['model_revisions']['AutonLab/MOMENT-1-large']}",
+            "task_name: classification",
+            "strategy: linear_probe_then_peft",
+            "precision: bf16",
+            "max_epochs: 5",
+            "early_stopping_patience: 2",
+            "batch_size: 64",
+            "learning_rate: 0.0001",
+            "checkpoint_cap_gb: 5",
+            "dataset_path: null",
+            "adapter_required: true",
+            f"source: {plan['classification']['source']}",
+            "",
+        ]
+    )
+
+
+def _foundation_commands(plan: dict[str, Any]) -> str:
+    return "\n".join(
+        [
+            "#!/usr/bin/env bash",
+            "set -euo pipefail",
+            "",
+            "echo 'foundation-gpu-plan is plan-only; no training or evaluation is launched by this script.'",
+            "echo 'Materialize adapters and lock package versions before using the upstream training recipes.'",
+            "",
+            "# Suggested GPU setup once the plan is promoted to an executable training run:",
+            "# python -m pip install --index-url https://download.pytorch.org/whl/cu128 torch torchvision",
+            "# python -m pip install 'chronos-forecasting>=2.0,<3' momentfm",
+            "",
+            "python - <<'PY'",
+            "from pathlib import Path",
+            "required = [",
+            "    Path('outputs/autoresearch/foundation-gpu-plan/m4_monthly_mini.arrow'),",
+            "    Path('outputs/autoresearch/foundation-gpu-plan/windowed_activity_dataset.npz'),",
+            "]",
+            "missing = [str(path) for path in required if not path.exists()]",
+            "if missing:",
+            "    print('adapter outputs not present yet: ' + ', '.join(missing))",
+            "else:",
+            "    print('adapter outputs are present')",
+            "PY",
+            "",
+            f"# run_id: {plan['run_id']}",
+            "",
+        ]
+    )
+
+
+def _foundation_report(plan: dict[str, Any]) -> str:
+    revision_lines = [
+        f"- `{model}` revision `{revision}`"
+        for model, revision in plan["model_revisions"].items()
+    ]
+    lines = [
+        "# Foundation GPU Plan",
+        "",
+        "This loop is plan-only. It materializes pinned model choices, config templates,",
+        "and adapter requirements, but it does not train, fine-tune, or evaluate models.",
+        "",
+        f"- target hardware: `{plan['target_hardware']}`",
+        "- forecasting foundation model: `amazon/chronos-2`",
+        "- forecasting fine-tune fallback: `amazon/chronos-t5-small`",
+        "- classification foundation model: `AutonLab/MOMENT-1-large`",
+        "",
+        "## Revisions",
+        "",
+    ]
+    lines.extend(revision_lines)
+    lines.extend(
+        [
+            "",
+            "## Budget",
+            "",
+            f"- timeout seconds: `{plan['budget']['timeout_seconds']}`",
+            f"- max planned runs: `{plan['budget']['max_trials']}`",
+            "- smoke: 30 minutes, one seed, up to 1000 steps",
+            "- full: 4 hours, three seeds, bf16, checkpoint cap 5 GiB",
+            "",
+            "## Required Adapters",
+            "",
+        ]
+    )
+    lines.extend(f"- {item}" for item in plan["adapter_requirements"])
+    lines.extend(
+        [
+            "",
+            "## Artifacts",
+            "",
+            "- `foundation_gpu_plan.json`",
+            "- `chronos_finetune_config.yaml`",
+            "- `moment_classification_config.yaml`",
+            "- `commands.sh`",
+            "",
+        ]
+    )
+    return "\n".join(lines)

--- a/ts_agents/cli/main.py
+++ b/ts_agents/cli/main.py
@@ -1930,6 +1930,14 @@ def _default_autoresearch_output_dir(loop_name: str) -> str:
     return str((Path("outputs") / "autoresearch" / loop_name / generate_workflow_run_id()).resolve())
 
 
+def _artifact_path(artifact: Any) -> Optional[str]:
+    if isinstance(artifact, dict):
+        path = artifact.get("path")
+    else:
+        path = getattr(artifact, "path", None)
+    return str(path) if path is not None else None
+
+
 def _synchronize_autoresearch_manifest(result: Any, execution: Any) -> None:
     if not isinstance(result, dict):
         return
@@ -1961,7 +1969,9 @@ def _synchronize_autoresearch_manifest(result: Any, execution: Any) -> None:
     manifest_payload["warnings"] = to_jsonable(result.get("warnings") or [])
     manifest_payload["best_config"] = to_jsonable(data.get("best_config") or {})
     if isinstance(result.get("artifacts"), list):
-        manifest_payload["artifacts"] = to_jsonable(result["artifacts"])
+        manifest_payload["artifacts"] = to_jsonable(
+            [artifact for artifact in result["artifacts"] if _artifact_path(artifact) != str(manifest_path)]
+        )
     if execution_metadata:
         manifest_payload["execution"] = dict(execution_metadata)
     try:
@@ -2040,9 +2050,9 @@ def _handle_autoresearch_command(args: argparse.Namespace) -> Tuple[Any, Optiona
     sandbox_mode = args.sandbox or os.environ.get("TS_AGENTS_SANDBOX_MODE")
     context = ExecutionContext(
         sandbox_mode=sandbox_mode,
-        timeout_seconds=args.timeout_seconds or loop.budget.timeout_seconds,
-        memory_mb=args.memory_mb or loop.budget.memory_mb,
-        disk_mb=args.disk_mb or loop.budget.disk_mb,
+        timeout_seconds=args.timeout_seconds if args.timeout_seconds is not None else loop.budget.timeout_seconds,
+        memory_mb=args.memory_mb if args.memory_mb is not None else loop.budget.memory_mb,
+        disk_mb=args.disk_mb if args.disk_mb is not None else loop.budget.disk_mb,
         allow_network=getattr(args, "allow_network", False),
         allow_fallback=allow_fallback,
         fallback_backend=fallback_backend,

--- a/ts_agents/cli/main.py
+++ b/ts_agents/cli/main.py
@@ -500,6 +500,8 @@ def _command_label(args: argparse.Namespace) -> str:
         return f"sandbox {args.sandbox_command}"
     if args.command == "workflow":
         return f"workflow {args.workflow_command}"
+    if args.command == "autoresearch":
+        return f"autoresearch {args.autoresearch_command}"
     if args.command == "run":
         return "tool run"
     return args.command
@@ -517,6 +519,9 @@ def _command_target_name(args: argparse.Namespace, exc: Optional[Exception] = No
     if args.command == "workflow":
         if args.workflow_command in {"run", "show"}:
             return getattr(args, "workflow_name", None)
+    if args.command == "autoresearch":
+        if args.autoresearch_command in {"run", "show"}:
+            return getattr(args, "loop_name", None)
     if args.command == "skills":
         if args.skills_command == "show":
             return getattr(args, "skill", None)
@@ -559,6 +564,20 @@ def _command_input_payload(args: argparse.Namespace) -> Dict[str, Any]:
     if args.command == "skills":
         return {k: v for k, v in vars(args).items() if k not in {"json", "save", "extract_images"}}
     if args.command == "workflow":
+        return {
+            k: v
+            for k, v in vars(args).items()
+            if k
+            not in {
+                "json",
+                "save",
+                "extract_images",
+                "_ts_input_payload",
+                "_ts_execution_result",
+                "_ts_raw_argv",
+            }
+        }
+    if args.command == "autoresearch":
         return {
             k: v
             for k, v in vars(args).items()
@@ -900,7 +919,7 @@ def _infer_command_label_from_argv(argv: List[str]) -> str:
         return "ts-agents"
 
     command = argv[0]
-    if command in {"tool", "workflow", "data", "sandbox", "skills", "agent", "demo", "capabilities"}:
+    if command in {"tool", "workflow", "autoresearch", "data", "sandbox", "skills", "agent", "demo", "capabilities"}:
         if len(argv) > 1 and not argv[1].startswith("-"):
             return f"{command} {argv[1]}"
     return command
@@ -1542,6 +1561,70 @@ def _add_workflow_subcommands(subparsers: argparse._SubParsersAction) -> None:
     _add_output_args(activity_parser)
 
 
+
+def _add_autoresearch_subcommands(subparsers: argparse._SubParsersAction) -> None:
+    autoresearch_parser = subparsers.add_parser(
+        "autoresearch",
+        help="Dataset/model/metric research loops for constrained and GPU runs",
+    )
+    autoresearch_sub = autoresearch_parser.add_subparsers(dest="autoresearch_command", required=True)
+
+    list_parser = autoresearch_sub.add_parser("list", help="List built-in autoresearch loops")
+    _add_output_args(list_parser)
+
+    show_parser = autoresearch_sub.add_parser("show", help="Show metadata for one autoresearch loop")
+    show_parser.add_argument("loop_name", type=str, help="Autoresearch loop name")
+    _add_output_args(show_parser)
+
+    run_parser = autoresearch_sub.add_parser(
+        "run",
+        help="Run an autoresearch loop",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=(
+            "Examples:\n"
+            "  ts-agents autoresearch list --json\n"
+            "  ts-agents autoresearch show forecast-daytona --json\n"
+            "  ts-agents autoresearch run forecast-daytona --models seasonal_naive --profile smoke --json\n"
+            "  ts-agents autoresearch run classify-daytona --dataset synthetic --profile smoke --json\n"
+            "  ts-agents autoresearch run foundation-gpu-plan --json"
+        ),
+    )
+    run_parser.add_argument("loop_name", type=str, help="Autoresearch loop name")
+    run_parser.add_argument(
+        "--output-dir",
+        type=str,
+        default=None,
+        help="Output directory. If omitted, a run-scoped directory is created under outputs/autoresearch/<loop>.",
+    )
+    run_parser.add_argument(
+        "--profile",
+        choices=["smoke", "default", "full"],
+        default="default",
+        help="Run profile controlling default trial count and dataset slice.",
+    )
+    run_parser.add_argument(
+        "--models",
+        type=_split_csv,
+        default=None,
+        help="Comma-separated model/classifier list. Defaults depend on the loop.",
+    )
+    run_parser.add_argument("--max-trials", type=int, default=None, help="Maximum model/evaluation-spec rows to execute.")
+    run_parser.add_argument("--timeout-seconds", type=int, default=None, help="Loop timeout budget in seconds.")
+    run_parser.add_argument("--memory-mb", type=int, default=None, help="Sandbox memory budget in MiB; local execution records but does not enforce it.")
+    run_parser.add_argument("--disk-mb", type=int, default=None, help="Sandbox disk budget in MiB; local execution records but does not enforce it.")
+    run_parser.add_argument(
+        "--dataset",
+        choices=["auto", "wisdm_subset", "synthetic"],
+        default="auto",
+        help="Classification dataset selector; forecasting/foundation loops ignore this option.",
+    )
+    run_parser.add_argument("--seed", type=int, default=1337, help="Random seed for generated data and splits.")
+    run_parser.add_argument("--dry-run", action="store_true", help="Write the run plan/artifacts without training models.")
+    run_parser.add_argument("--skip-plots", action="store_true", help="Skip optional ranking plots.")
+    run_parser.add_argument("--overwrite", action="store_true", help="Replace an existing non-empty output directory.")
+    _add_sandbox_execution_args(run_parser)
+    _add_output_args(run_parser)
+
 def _resolve_runtime_path(path: str) -> Path:
     from ts_agents.runtime_paths import resolve_existing_path
 
@@ -1805,6 +1888,7 @@ def build_parser(*, exit_on_error: bool = True) -> argparse.ArgumentParser:
 
     _add_capabilities_subcommand(subparsers)
     _add_workflow_subcommands(subparsers)
+    _add_autoresearch_subcommands(subparsers)
     _add_tool_subcommands(subparsers)
     _add_sandbox_subcommands(subparsers)
     _add_skills_subcommands(subparsers)
@@ -1823,6 +1907,155 @@ def _resolve_use_test_data(args: argparse.Namespace) -> Optional[bool]:
         return False
     return None
 
+
+
+def _autoresearch_summary_dict(loop: Any) -> Dict[str, Any]:
+    from ts_agents.autoresearch import loop_to_dict
+
+    details = loop_to_dict(loop)
+    return {
+        "name": details["name"],
+        "task": details["task"],
+        "description": details["description"],
+        "dataset": details["dataset"],
+        "models": details["models"],
+        "primary_metric": details["primary_metric"],
+        "budget": details["budget"],
+    }
+
+
+def _default_autoresearch_output_dir(loop_name: str) -> str:
+    from ts_agents.workflows.common import generate_workflow_run_id
+
+    return str((Path("outputs") / "autoresearch" / loop_name / generate_workflow_run_id()).resolve())
+
+
+def _synchronize_autoresearch_manifest(result: Any, execution: Any) -> None:
+    if not isinstance(result, dict):
+        return
+    data = result.get("data")
+    if not isinstance(data, dict):
+        return
+
+    execution_metadata = _workflow_execution_metadata(execution)
+    if execution_metadata:
+        data["execution"] = dict(execution_metadata)
+
+    manifest_path_raw = data.get("manifest_path")
+    if not isinstance(manifest_path_raw, str):
+        return
+    manifest_path = Path(manifest_path_raw)
+    if not manifest_path.exists():
+        return
+    try:
+        manifest_payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return
+    if not isinstance(manifest_payload, dict):
+        return
+
+    manifest_payload["status"] = result.get("status", manifest_payload.get("status"))
+    manifest_payload["summary"] = result.get("summary", manifest_payload.get("summary"))
+    manifest_payload["output_dir"] = data.get("output_dir", manifest_payload.get("output_dir"))
+    manifest_payload["manifest_path"] = str(manifest_path)
+    manifest_payload["warnings"] = to_jsonable(result.get("warnings") or [])
+    manifest_payload["best_config"] = to_jsonable(data.get("best_config") or {})
+    if isinstance(result.get("artifacts"), list):
+        manifest_payload["artifacts"] = to_jsonable(result["artifacts"])
+    if execution_metadata:
+        manifest_payload["execution"] = dict(execution_metadata)
+    try:
+        write_output(render_output(to_jsonable(manifest_payload), json_output=True), str(manifest_path))
+    except OSError:
+        return
+
+
+def _handle_autoresearch_command(args: argparse.Namespace) -> Tuple[Any, Optional[str]]:
+    from ts_agents.autoresearch import get_loop, list_loops, loop_to_dict
+    from ts_agents.autoresearch.executor import execute_autoresearch
+    from ts_agents.tools.executor import ExecutionContext
+
+    if args.autoresearch_command == "list":
+        loops = list_loops()
+        result = {"loops": [_autoresearch_summary_dict(loop) for loop in loops]}
+        lines = ["Autoresearch loops:"]
+        for loop in loops:
+            lines.append(f"- {loop.name} [{loop.task}]: {loop.description}")
+        return result, "\n".join(lines)
+
+    if args.autoresearch_command == "show":
+        try:
+            loop = get_loop(args.loop_name)
+        except KeyError as exc:
+            raise ValueError(str(exc)) from exc
+        result = loop_to_dict(loop)
+        lines = [
+            f"Autoresearch loop: {result['name']}",
+            f"Task: {result['task']}",
+            f"Dataset: {result['dataset']}",
+            f"Models: {', '.join(result['models'])}",
+            f"Primary metric: {result['primary_metric']}",
+            f"Budget: {result['budget']['vcpu']} vCPU, {result['budget']['memory_mb']} MiB RAM, {result['budget']['disk_mb']} MiB disk",
+        ]
+        return result, "\n".join(lines)
+
+    if args.autoresearch_command != "run":
+        raise ValueError(f"Unknown autoresearch command: {args.autoresearch_command}")
+
+    try:
+        loop = get_loop(args.loop_name)
+    except KeyError as exc:
+        raise ValueError(str(exc)) from exc
+
+    allow_fallback = getattr(args, "allow_fallback", False)
+    fallback_backend = getattr(args, "fallback_backend", None) or "local"
+    if getattr(args, "fallback_backend", None) and not allow_fallback:
+        raise ValueError(
+            "--fallback-backend requires --allow-fallback to take effect. "
+            "Pass --allow-fallback to opt in to backend fallback."
+        )
+
+    output_dir = args.output_dir or _default_autoresearch_output_dir(args.loop_name)
+    options = {
+        "output_dir": output_dir,
+        "profile": args.profile,
+        "models": args.models,
+        "max_trials": args.max_trials,
+        "timeout_seconds": args.timeout_seconds,
+        "overwrite": args.overwrite,
+        "dry_run": args.dry_run,
+        "skip_plots": args.skip_plots,
+        "seed": args.seed,
+        "dataset": args.dataset,
+    }
+    args._ts_input_payload = {
+        "loop": args.loop_name,
+        "definition": _autoresearch_summary_dict(loop),
+        "options": options,
+        "sandbox": args.sandbox or os.environ.get("TS_AGENTS_SANDBOX_MODE") or "local",
+        "allow_fallback": allow_fallback,
+        "fallback_backend": fallback_backend,
+    }
+
+    sandbox_mode = args.sandbox or os.environ.get("TS_AGENTS_SANDBOX_MODE")
+    context = ExecutionContext(
+        sandbox_mode=sandbox_mode,
+        timeout_seconds=args.timeout_seconds or loop.budget.timeout_seconds,
+        memory_mb=args.memory_mb or loop.budget.memory_mb,
+        disk_mb=args.disk_mb or loop.budget.disk_mb,
+        allow_network=getattr(args, "allow_network", False),
+        allow_fallback=allow_fallback,
+        fallback_backend=fallback_backend,
+    )
+    execution = execute_autoresearch(args.loop_name, options, context=context)
+    args._ts_execution_result = execution
+    if not execution.success:
+        if execution.error:
+            raise execution.error
+        raise RuntimeError(execution.formatted_output or "Autoresearch execution failed")
+
+    _synchronize_autoresearch_manifest(execution.result, execution)
+    return execution.result, execution.formatted_output or None
 
 def _handle_data_command(args: argparse.Namespace) -> Tuple[Any, str]:
     from ts_agents import data_access
@@ -2053,6 +2286,11 @@ def _handle_capabilities_command(args: argparse.Namespace) -> Tuple[Any, str]:
                 "ts-agents workflow show <workflow> --json",
                 "ts-agents workflow run <workflow> ... --json",
             ],
+            "autoresearch": [
+                "ts-agents autoresearch list --json",
+                "ts-agents autoresearch show <loop> --json",
+                "ts-agents autoresearch run <loop> ... --json",
+            ],
             "tool_discovery": [
                 "ts-agents tool search <query> --json",
                 "ts-agents tool show <tool> --json",
@@ -2072,6 +2310,7 @@ def _handle_capabilities_command(args: argparse.Namespace) -> Tuple[Any, str]:
         "recommended_entrypoints": [
             "Start with `workflow list --json` for public workflows.",
             "Use `workflow show --json` before `workflow run` to inspect availability, options, artifacts, and source contracts.",
+            "Use `autoresearch show --json` before `autoresearch run` to inspect loop datasets, models, metrics, and budgets.",
             "Use `tool search --json` and `tool show --json` for lower-level execution.",
             "Always inspect top-level quality fields plus `result.status`, `warnings`, and workflow `quality_flags` rather than relying on exit code 0 alone.",
         ],
@@ -2502,7 +2741,8 @@ def _handle_agent_command(args: argparse.Namespace) -> Tuple[Any, Optional[str]]
 
     callback = None
     if args.approval == "auto":
-        callback = lambda tool_name: True
+        def callback(_tool_name: str) -> bool:
+            return True
     elif args.approval == "prompt":
         callback = _approval_prompt
 
@@ -2983,7 +3223,6 @@ def _run_demo_window_classification_scripted(args: argparse.Namespace) -> Dict[s
 
 
 def _run_demo_window_classification_llm(args: argparse.Namespace) -> Dict[str, Any]:
-    import json
     import subprocess
     from pathlib import Path
 
@@ -3322,6 +3561,8 @@ def run(argv: Optional[List[str]] = None) -> int:
             result, text = _handle_skills_command(args)
         elif args.command == "workflow":
             result, text = _handle_workflow_command(args)
+        elif args.command == "autoresearch":
+            result, text = _handle_autoresearch_command(args)
         elif args.command == "demo":
             result, text = _handle_demo_command(args)
         else:

--- a/ts_agents/sandbox/runner.py
+++ b/ts_agents/sandbox/runner.py
@@ -39,6 +39,10 @@ def run_request(payload: Dict[str, Any]) -> Dict[str, Any]:
     """Execute a tool request payload and return a serialized ExecutionResult."""
 
     from ts_agents.tools.executor import ExecutionContext, SandboxMode, execute_tool
+    from ts_agents.autoresearch.executor import (
+        execute_serialized_autoresearch_request,
+        is_autoresearch_target,
+    )
     from ts_agents.workflows.executor import (
         execute_serialized_workflow_request,
         is_workflow_target,
@@ -75,6 +79,13 @@ def run_request(payload: Dict[str, Any]) -> Dict[str, Any]:
         workflow_name = tool_name.split(":", 1)[1]
         result = execute_serialized_workflow_request(
             workflow_name=workflow_name,
+            kwargs=kwargs,
+            context=context,
+        )
+    elif is_autoresearch_target(tool_name):
+        loop_name = tool_name.split(":", 1)[1]
+        result = execute_serialized_autoresearch_request(
+            loop_name=loop_name,
             kwargs=kwargs,
             context=context,
         )

--- a/ts_agents/tools/executor.py
+++ b/ts_agents/tools/executor.py
@@ -34,7 +34,7 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from enum import Enum
 from pathlib import Path, PurePosixPath
-from typing import Any, Callable, Dict, List, Optional, Type, Union
+from typing import Any, Callable, Dict, List, Optional, Union
 
 from ts_agents.cli.output import dump_json
 
@@ -1318,6 +1318,10 @@ class DaytonaBackend(ExecutorBackend):
 
             daytona = Daytona()
             daytona_snapshot = os.environ.get("TS_AGENTS_DAYTONA_SNAPSHOT", context.daytona_snapshot or "").strip() or None
+            daytona_repo_branch = os.environ.get(
+                "TS_AGENTS_DAYTONA_REPO_BRANCH",
+                context.daytona_repo_branch or "",
+            ).strip() or None
             create_params = CreateSandboxFromSnapshotParams(
                 language=context.daytona_language or "python",
                 name=context.daytona_name,
@@ -1335,14 +1339,14 @@ class DaytonaBackend(ExecutorBackend):
                         sandbox.git.clone(
                             context.daytona_repo_url,
                             path=repo_path,
-                            branch=context.daytona_repo_branch,
+                            branch=daytona_repo_branch,
                             username=context.daytona_git_username,
                             password=context.daytona_git_password,
                         )
                     else:
                         branch_part = ""
-                        if context.daytona_repo_branch:
-                            branch_part = f"--branch {shlex.quote(context.daytona_repo_branch)} --single-branch "
+                        if daytona_repo_branch:
+                            branch_part = f"--branch {shlex.quote(daytona_repo_branch)} --single-branch "
                         clone_cmd = (
                             f"rm -rf {shlex.quote(repo_path)} && "
                             f"git clone {branch_part}{shlex.quote(context.daytona_repo_url)} {shlex.quote(repo_path)}"
@@ -1373,14 +1377,25 @@ class DaytonaBackend(ExecutorBackend):
                             )
 
                     if context.daytona_install_editable:
-                        install_cmd = (
-                            "bash -lc "
-                            + shlex.quote(
-                                "python -m venv .ts-agents-venv && "
-                                ". .ts-agents-venv/bin/activate && "
-                                "python -m pip install -e ."
+                        install_extras = (
+                            (context.environment or {}).get("TS_AGENTS_DAYTONA_INSTALL_EXTRAS")
+                            or os.environ.get("TS_AGENTS_DAYTONA_INSTALL_EXTRAS")
+                            or ""
+                        ).strip()
+                        install_target = "."
+                        if install_extras:
+                            cleaned_extras = ",".join(
+                                part.strip()
+                                for part in install_extras.split(",")
+                                if part.strip()
                             )
+                            install_target = f".[{cleaned_extras}]" if cleaned_extras else "."
+                        install_inner = (
+                            "python -m venv .ts-agents-venv && "
+                            ". .ts-agents-venv/bin/activate && "
+                            f"python -m pip install -e {shlex.quote(install_target)}"
                         )
+                        install_cmd = "bash -lc " + shlex.quote(install_inner)
                         install_exit, install_output = self._run_command(
                             sandbox,
                             install_cmd,


### PR DESCRIPTION
## Summary
- add `ts-agents autoresearch list|show|run` with benchmark-style forecast/classification loops for constrained Daytona-style resources
- rename the foundation path to `foundation-gpu-plan`, mark it plan-only, pin model revisions, and stop surfacing fake metric-backed `best_config`
- rank forecast trials across holdout and rolling-origin rows, unify `--max-trials` as model/evaluation rows, add per-trial wall-clock guards, and remove the duplicate classification final evaluation pass
- add sandbox artifact staging for autoresearch, env-configurable bundle limits, Daytona branch/extras support, docs, and tests

## Verification
- `uv run ruff check ts_agents/cli/main.py ts_agents/autoresearch ts_agents/tools/executor.py ts_agents/sandbox/runner.py tests/cli/test_autoresearch.py`
- `uv run python -m pytest -q tests/cli/test_autoresearch.py`
- `uv run python -m pytest -q`
- local loop: `uv run ts-agents autoresearch run forecast-daytona --output-dir /tmp/ts-agents-review-autoresearch/forecast-daytona --overwrite --json`
- local loop: `uv run ts-agents autoresearch run classify-daytona --profile smoke --dataset synthetic --output-dir /tmp/ts-agents-review-autoresearch/classify-daytona --overwrite --json`
- local loop: `uv run ts-agents autoresearch run foundation-gpu-plan --output-dir /tmp/ts-agents-review-autoresearch/foundation-gpu-plan --overwrite --json`

Closes #90
