### PR TITLE
[codex] Clarify TSFM scope and deep-agent fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@ on time-series data. It gives agent runtimes a stable, machine-readable surface
 so a model can bootstrap, discover what's available, execute real work, and
 produce inspectable artifacts — without hand-written glue code per project.
 
+It is not intended to be a broad time-series foundation-model hub.
+Foundation-model support is kept scoped to executable smoke paths and
+planning artifacts that exercise the same CLI/workflow contract.
+
 It is built around:
 - a stable CLI contract for bootstrap, discovery, and execution (`ts-agents capabilities`, `ts-agents workflow ...`, `ts-agents tool ...`)
 - strict JSON envelopes with `schema_version`, typed exit codes, top-level `quality_status`/`degraded`/`requires_review`, and nested workflow `result.status`/`result.data.quality_flags`
@@ -27,6 +31,7 @@ It also includes autoresearch loops for repeatable dataset/model/metric
 experiments:
 - `forecast-daytona` (M4 mini forecasting baselines under constrained resources)
 - `classify-daytona` (windowed activity classification under constrained resources)
+- `foundation-chronos-smoke` (optional Chronos zero-shot smoke run on M4 mini)
 - `foundation-gpu-plan` (plan-only Chronos/MOMENT GPU fine-tuning recipes)
 
 Legacy compatibility aliases for `ts-agents demo ...` remain available for one
@@ -88,13 +93,17 @@ ts-agents autoresearch list --json
 ts-agents autoresearch show forecast-daytona --json
 ts-agents autoresearch run forecast-daytona --profile smoke --models seasonal_naive --json
 ts-agents autoresearch run classify-daytona --profile smoke --dataset synthetic --models knn --json
+ts-agents autoresearch run foundation-chronos-smoke --dry-run --json
 ts-agents autoresearch run foundation-gpu-plan --json
 ```
 
 Pass `--sandbox daytona` to run an autoresearch loop through the Daytona
 backend after configuring `DAYTONA_API_KEY`; use `--dry-run` to materialize the
-trial plan without fitting models. `foundation-gpu-plan` is intentionally
-plan-only and reports no trained-model metrics.
+trial plan without fitting models. `foundation-chronos-smoke` is the only
+executable foundation-model loop; real runs require `ts-agents[foundation]`
+and lazy-load `chronos`/`torch`, while dry-run mode needs no heavy TSFM
+dependencies. `foundation-gpu-plan` is intentionally plan-only and reports no
+trained-model metrics.
 
 ### 3. Use the low-level CLI on bundled or custom data
 
@@ -232,6 +241,7 @@ Use `ts-agents` when you want:
 - a stable CLI contract that works the same across workflows, agents, and automation
 - artifact-first outputs (plots, JSON, markdown/report assets) instead of chat-only responses
 - reusable skills and tool bundles that encode workflow guidance
+- scoped foundation-model smoke paths without taking on model-hub ownership
 - optional sandbox backends for isolation, deployment, and heavier workloads
 - swappable front ends: CLI, Gradio UI, or custom agent orchestration
 
@@ -239,7 +249,8 @@ Use `ts-agents` when you want:
 
 - **CLI as the stable contract**: `ts-agents` is the primary interface for automation and reproducibility. Autonomous agents plan against `capabilities`, `workflow show`, and `tool show` instead of hardcoded knowledge.
 - **Strict machine envelopes**: `--json` output is versioned, strict, and typed — with status, quality flags, and exit codes — so agents can branch on failure mode rather than parsing prose.
-- **Framework adapters, not framework lock-in**: LangChain/deep-agent wrappers are convenience layers over the same tool registry.
+- **Framework adapters, not framework lock-in**: LangChain/deep-agent wrappers are convenience layers over the same tool registry. If `deepagents` is unavailable, deep mode reports a LangChain fallback instead of hiding the runtime downgrade.
+- **Scoped TSFM interop, not a model hub**: external projects such as TimeCopilot are comparator and interoperability targets; `ts-agents` keeps foundation-model execution to narrow smoke paths plus reproducible artifacts.
 - **Artifacts over chat**: tools produce inspectable files (plots, JSON, reports), and agents return summaries plus paths.
 - **Run lifecycle as first-class metadata**: every workflow run gets a run ID, a `run_manifest.json`, and non-clobbering defaults — so long, multi-turn sessions remain reproducible and resumable.
 - **Swappable front-ends**: CLI agents, custom agents, and Gradio are interfaces around the same core tools.

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -31,3 +31,15 @@ And three tasks:
 - inspect a short univariate series
 - compare forecasting baselines
 - run labeled-stream activity recognition
+
+## External benchmark context
+
+`benchmarks/external/` records external comparator context. It is not a
+ts-agents leaderboard submission. The current snapshot tracks GIFT-Eval
+and TimeCopilot as forecasting benchmark/interop references so roadmap
+decisions can be grounded without turning this repo into a model hub.
+
+Files:
+
+- `benchmarks/external/gift_eval_snapshot.json` — machine-readable external context
+- `benchmarks/external/summary.md` — compact reading guide

--- a/benchmarks/external/gift_eval_snapshot.json
+++ b/benchmarks/external/gift_eval_snapshot.json
@@ -1,0 +1,53 @@
+{
+  "schema_version": "1.0",
+  "snapshot_date": "2026-06-04",
+  "purpose": "External benchmark context for ts-agents roadmap decisions. This is not a ts-agents score submission or leaderboard claim.",
+  "benchmarks": [
+    {
+      "name": "GIFT-Eval",
+      "type": "external_forecasting_benchmark",
+      "primary_source": "https://arxiv.org/abs/2410.10393",
+      "leaderboard": "https://huggingface.co/spaces/Salesforce/GIFT-Eval",
+      "scope": {
+        "datasets": 23,
+        "time_series": "144000+",
+        "data_points": "177M",
+        "domains": 7,
+        "frequencies": 10,
+        "supports_multivariate_inputs": true
+      },
+      "why_relevant": "GIFT-Eval is a credible external yardstick for foundation-model forecasting claims. ts-agents should reference it when discussing forecasting accuracy, but should not imply leadership without a submitted or reproducibly generated result."
+    }
+  ],
+  "comparators": [
+    {
+      "project": "TimeCopilot",
+      "repository": "https://github.com/TimeCopilot/timecopilot",
+      "model_hub": "https://timecopilot.dev/model-hub/",
+      "gift_eval_experiment": "https://timecopilot.dev/experiments/gift-eval/",
+      "observed_positioning": "Forecasting agent and unified API over foundation, statistical, machine-learning, and neural forecasting models.",
+      "published_claims_to_treat_as_external_context": [
+        "Combines LLM reasoning with many time-series foundation models.",
+        "Documents a GIFT-Eval foundation-model ensemble result."
+      ],
+      "roadmap_relevance": "Use as a benchmark/interop target and comparison point; do not copy its broad model-hub scope into ts-agents."
+    }
+  ],
+  "ts_agents_boundary": {
+    "primary_product_surface": [
+      "CLI contracts",
+      "workflow manifests",
+      "artifact bundles",
+      "sandbox execution",
+      "agent-facing skills and tool discovery"
+    ],
+    "allowed_foundation_model_scope": "One or a few executable smoke paths that validate contracts and provide external-comparator hooks. Avoid maintaining a large TSFM catalog.",
+    "current_executable_tsfm_path": "autoresearch/foundation-chronos-smoke",
+    "plan_only_tsfm_path": "autoresearch/foundation-gpu-plan"
+  },
+  "recommended_next_external_checks": [
+    "Generate a GIFT-Eval-compatible export artifact before claiming external accuracy.",
+    "Compare artifact format and workflow ergonomics against TimeCopilot examples.",
+    "Keep TimeCopilot references in docs as comparator context, not product direction."
+  ]
+}

--- a/benchmarks/external/summary.md
+++ b/benchmarks/external/summary.md
@@ -1,0 +1,17 @@
+# External Benchmark Context
+
+Snapshot date: 2026-06-04
+
+This directory records external benchmark and comparator context for `ts-agents`. It is intentionally separate from the internal refactor benchmark under `benchmarks/results/latest/`.
+
+## GIFT-Eval
+
+GIFT-Eval is the relevant external forecasting benchmark to reference before making foundation-model accuracy claims. The checked snapshot records its published scope: 23 datasets, 144k+ time series, 177M data points, seven domains, and 10 frequencies.
+
+## TimeCopilot
+
+TimeCopilot is tracked as a comparator and interoperability target because it focuses on foundation-model forecasting breadth. That is not the desired product direction for `ts-agents`; the repo should stay centered on CLI contracts, workflow manifests, artifacts, sandboxes, and reusable skills.
+
+## Local TSFM Scope
+
+`foundation-chronos-smoke` is the scoped executable TSFM path. It exists to validate one Chronos zero-shot route through the same autoresearch artifact contract, not to become a model hub.

--- a/docs/evaluation.qmd
+++ b/docs/evaluation.qmd
@@ -61,6 +61,23 @@ Results from the current snapshot:
 - `structured_discovery` reaches full task success, but it still leaves artifact completeness at `0.00` because raw tool calls do not write the workflow bundle.
 - `skills_workflows` reaches full task success and full artifact completeness, which is the main proof that the repo's structured surface improves agent outcomes.
 
+## External Context
+
+The checked-in internal benchmark is contract evidence, not an accuracy leaderboard.
+External forecasting claims should be compared against benchmark surfaces such as
+GIFT-Eval before being presented as model-performance evidence. The repo now tracks
+that context in:
+
+- `benchmarks/external/gift_eval_snapshot.json`
+- `benchmarks/external/summary.md`
+
+TimeCopilot is treated as a comparator and interoperability target because it has a
+broad foundation-model forecasting surface. That is intentionally different from
+`ts-agents`, whose durable surface is CLI contracts, workflow manifests, artifact
+bundles, sandboxes, and reusable skills. The scoped `foundation-chronos-smoke`
+loop exists to validate one executable TSFM route through the same artifact
+contract, not to start a model hub.
+
 ## Why this matters
 
 This benchmark closes the loop on the refactor:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,10 @@ classification = [
     "aeon>=1.3.0",
     "scikit-learn>=1.7.2",
 ]
+foundation = [
+    "chronos-forecasting>=2.0,<3",
+    "torch>=2.0",
+]
 recommended = [
     "aeon>=1.3.0",
     "gradio>=6.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,7 @@ recommended = [
 ]
 all = [
     "aeon>=1.3.0",
+    "chronos-forecasting>=2.0,<3",
     "gradio>=6.0",
     "langchain>=1.0",
     "langchain-core>=1.0",
@@ -84,6 +85,7 @@ all = [
     "statsforecast>=2.0.3",
     "statsmodels>=0.14.2",
     "stumpy>=1.13.0",
+    "torch>=2.0",
 ]
 
 [project.urls]

--- a/tests/agents/test_deep_agent.py
+++ b/tests/agents/test_deep_agent.py
@@ -1,8 +1,5 @@
 """Tests for deep agent module."""
 
-import pytest
-
-
 class TestSubagentDefinitions:
     """Tests for subagent configurations."""
 
@@ -165,7 +162,7 @@ class TestDeepAgentTurn:
         assert len(turn.subagent_calls) == 1
         assert turn.subagent_calls[0].subagent_name == "turbulence-agent"
         assert turn.duration_ms == 3000.0
-        assert turn.required_approval == False
+        assert not turn.required_approval
 
     def test_deep_agent_turn_with_approval(self):
         """Test deep agent turn that required approval."""
@@ -178,7 +175,7 @@ class TestDeepAgentTurn:
             duration_ms=60000.0,  # Long running
         )
 
-        assert turn.required_approval == True
+        assert turn.required_approval
 
 
 class TestOrchestratorConfiguration:
@@ -224,7 +221,7 @@ class TestOrchestratorConfiguration:
         if config:  # Only if there are expensive tools
             assert isinstance(config, dict)
             for tool_name, should_interrupt in config.items():
-                assert should_interrupt == True
+                assert should_interrupt
 
     def test_create_interrupt_config_disabled(self):
         """Test interrupt config when approval is disabled."""
@@ -261,6 +258,88 @@ class TestOrchestratorConfiguration:
             enable_logging=False,
         )
         assert agent == {"ok": True}
+
+    def test_deep_agent_runtime_status_reports_missing_deepagents(self, monkeypatch):
+        import ts_agents.agents.deep.orchestrator as orchestrator
+
+        monkeypatch.setattr(
+            orchestrator,
+            "find_spec",
+            lambda name: None if name == "deepagents" else object(),
+        )
+
+        status = orchestrator.get_deep_agent_runtime_status()
+
+        assert status["agent_type"] == "deep_fallback"
+        assert status["runtime"] == "langchain"
+        assert status["fallback_used"] is True
+        assert status["missing_dependencies"] == ["deepagents"]
+        assert "pip install deepagents" in status["install_hint"]
+
+    def test_create_deep_agent_passes_fallback_status_to_langchain(self, monkeypatch):
+        import ts_agents.agents.deep.orchestrator as orchestrator
+
+        captured = {}
+
+        def raise_import_error(**_kwargs):
+            raise ImportError("missing deepagents")
+
+        def fake_langchain(**kwargs):
+            captured.update(kwargs)
+            return {"ok": True}
+
+        monkeypatch.setattr(orchestrator, "get_bundle", lambda name: [])
+        monkeypatch.setattr(orchestrator, "wrap_tools_for_deepagent", lambda bundle: [])
+        monkeypatch.setattr(orchestrator, "get_all_subagents", lambda: [])
+        monkeypatch.setattr(orchestrator, "_create_with_deepagents", raise_import_error)
+        monkeypatch.setattr(orchestrator, "_create_with_langchain", fake_langchain)
+        monkeypatch.setattr(
+            orchestrator,
+            "find_spec",
+            lambda name: None if name == "deepagents" else object(),
+        )
+
+        agent = orchestrator.create_deep_agent(
+            model_name="gpt-5-mini",
+            enable_approval=False,
+            enable_logging=False,
+        )
+
+        assert agent == {"ok": True}
+        assert captured["fallback_status"]["fallback_used"] is True
+        assert captured["fallback_status"]["missing_dependencies"] == ["deepagents"]
+        assert captured["fallback_status"]["fallback_reason"] == "missing deepagents"
+
+    def test_create_deep_agent_reports_installed_deepagents_import_error(self, monkeypatch):
+        import ts_agents.agents.deep.orchestrator as orchestrator
+
+        captured = {}
+
+        def raise_import_error(**_kwargs):
+            raise ImportError("cannot import name FilesystemMiddleware")
+
+        def fake_langchain(**kwargs):
+            captured.update(kwargs)
+            return {"ok": True}
+
+        monkeypatch.setattr(orchestrator, "get_bundle", lambda name: [])
+        monkeypatch.setattr(orchestrator, "wrap_tools_for_deepagent", lambda bundle: [])
+        monkeypatch.setattr(orchestrator, "get_all_subagents", lambda: [])
+        monkeypatch.setattr(orchestrator, "_create_with_deepagents", raise_import_error)
+        monkeypatch.setattr(orchestrator, "_create_with_langchain", fake_langchain)
+        monkeypatch.setattr(orchestrator, "find_spec", lambda _name: object())
+
+        agent = orchestrator.create_deep_agent(
+            model_name="gpt-5-mini",
+            enable_approval=False,
+            enable_logging=False,
+        )
+
+        assert agent == {"ok": True}
+        status = captured["fallback_status"]
+        assert status["missing_dependencies"] == []
+        assert "version" in status["install_hint"]
+        assert status["fallback_reason"] == "cannot import name FilesystemMiddleware"
 
 
 class TestUtilityFunctions:
@@ -430,11 +509,6 @@ class TestImports:
             DeepAgentChat,
             DeepAgentTurn,
             SubagentCall,
-            list_subagents,
-            get_expensive_tools,
-            run_with_approval,
-            get_all_subagents,
-            create_interrupt_config,
         )
 
         # All should be importable

--- a/tests/agents/test_deep_agent.py
+++ b/tests/agents/test_deep_agent.py
@@ -341,6 +341,39 @@ class TestOrchestratorConfiguration:
         assert "version" in status["install_hint"]
         assert status["fallback_reason"] == "cannot import name FilesystemMiddleware"
 
+    def test_create_deep_agent_reports_installed_deepagents_type_error(self, monkeypatch):
+        import ts_agents.agents.deep.orchestrator as orchestrator
+
+        captured = {}
+
+        def raise_type_error(**_kwargs):
+            raise TypeError(
+                "FilesystemMiddleware() takes 0 positional arguments but 1 was given"
+            )
+
+        def fake_langchain(**kwargs):
+            captured.update(kwargs)
+            return {"ok": True}
+
+        monkeypatch.setattr(orchestrator, "get_bundle", lambda name: [])
+        monkeypatch.setattr(orchestrator, "wrap_tools_for_deepagent", lambda bundle: [])
+        monkeypatch.setattr(orchestrator, "get_all_subagents", lambda: [])
+        monkeypatch.setattr(orchestrator, "_create_with_deepagents", raise_type_error)
+        monkeypatch.setattr(orchestrator, "_create_with_langchain", fake_langchain)
+        monkeypatch.setattr(orchestrator, "find_spec", lambda _name: object())
+
+        agent = orchestrator.create_deep_agent(
+            model_name="gpt-5-mini",
+            enable_approval=False,
+            enable_logging=False,
+        )
+
+        assert agent == {"ok": True}
+        status = captured["fallback_status"]
+        assert status["missing_dependencies"] == []
+        assert "middleware API compatibility" in status["install_hint"]
+        assert "FilesystemMiddleware" in status["fallback_reason"]
+
 
 class TestUtilityFunctions:
     """Tests for deep agent utility functions."""

--- a/tests/cli/test_autoresearch.py
+++ b/tests/cli/test_autoresearch.py
@@ -4,6 +4,7 @@ import signal
 import subprocess
 import time
 
+import numpy as np
 import pytest
 import yaml
 
@@ -20,6 +21,7 @@ def test_autoresearch_list_json_returns_loops(capsys):
     names = [loop["name"] for loop in payload["result"]["loops"]]
     assert "forecast-daytona" in names
     assert "classify-daytona" in names
+    assert "foundation-chronos-smoke" in names
     assert "foundation-gpu-plan" in names
 
 
@@ -158,6 +160,175 @@ def test_autoresearch_run_classification_dry_run(capsys, tmp_path):
     assert payload["result"]["data"]["trial_count"] == 1
     assert (output_dir / "synthetic_labeled_stream.csv").exists()
     assert (output_dir / "trials.csv").exists()
+
+
+def test_autoresearch_run_foundation_chronos_smoke_dry_run_writes_contract(
+    capsys, tmp_path
+):
+    output_dir = tmp_path / "chronos-dry-run"
+    code = run(
+        [
+            "autoresearch",
+            "run",
+            "foundation-chronos-smoke",
+            "--dry-run",
+            "--skip-plots",
+            "--output-dir",
+            str(output_dir),
+            "--json",
+        ]
+    )
+
+    assert code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["ok"] is True
+    assert payload["result"]["status"] == "ok"
+    assert payload["result"]["data"]["trial_count"] == 1
+    assert payload["result"]["data"]["best_config"] == {}
+    assert (output_dir / "trials.csv").exists()
+    assert (output_dir / "summary.json").exists()
+    assert (output_dir / "report.md").exists()
+    assert (output_dir / "run_manifest.json").exists()
+
+    report = (output_dir / "report.md").read_text()
+    assert "not a model hub" in report
+    summary = json.loads((output_dir / "summary.json").read_text())
+    assert (
+        summary["external_benchmark_context"]
+        == "benchmarks/external/gift_eval_snapshot.json"
+    )
+    manifest = json.loads((output_dir / "run_manifest.json").read_text())
+    assert manifest["loop"] == "foundation-chronos-smoke"
+    assert manifest["options"]["model_scope"] == "single_chronos_zero_shot_smoke"
+    assert manifest["options"]["model_scope_label"] == "single Chronos-family zero-shot smoke path"
+
+
+def test_autoresearch_run_foundation_chronos_smoke_executes_with_mocked_adapter(
+    monkeypatch, capsys, tmp_path
+):
+    import ts_agents.autoresearch.executor as executor_module
+    import ts_agents.autoresearch.runner as runner_module
+
+    monkeypatch.setattr(executor_module, "find_spec", lambda _name: object())
+
+    def fake_forecast(_model_id, series, *, horizon):
+        return np.full(horizon, float(series[-1]))
+
+    monkeypatch.setattr(runner_module, "_forecast_with_chronos", fake_forecast)
+    output_dir = tmp_path / "chronos-execute"
+    code = run(
+        [
+            "autoresearch",
+            "run",
+            "foundation-chronos-smoke",
+            "--max-trials",
+            "1",
+            "--skip-plots",
+            "--output-dir",
+            str(output_dir),
+            "--json",
+        ]
+    )
+
+    assert code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["ok"] is True
+    assert payload["result"]["status"] == "ok"
+    data = payload["result"]["data"]
+    assert data["trial_count"] == 1
+    assert data["model_scope"] == "single_chronos_zero_shot_smoke"
+    assert data["best_config"]["model"] == "amazon/chronos-t5-tiny"
+    assert data["best_config"]["n_trials"] == 1
+
+    trials = (output_dir / "trials.csv").read_text()
+    assert "foundation-model-smoke" in trials
+    assert "season_length" not in trials
+    assert data["best_config"]["smape"] is not None
+
+
+def test_autoresearch_foundation_chronos_smoke_preflight_reports_missing_deps(
+    monkeypatch, tmp_path
+):
+    import ts_agents.autoresearch.executor as executor_module
+    from ts_agents.autoresearch.executor import AutoresearchExecutor
+    from ts_agents.tools.executor import ExecutionContext, SandboxMode, ToolErrorCode
+
+    def fake_find_spec(name):
+        if name == "chronos":
+            return None
+        return object()
+
+    monkeypatch.setattr(executor_module, "find_spec", fake_find_spec)
+    result = AutoresearchExecutor().execute(
+        "foundation-chronos-smoke",
+        {"output_dir": str(tmp_path / "chronos-deps")},
+        context=ExecutionContext(sandbox_mode=SandboxMode.LOCAL),
+    )
+
+    assert not result.success
+    assert result.error is not None
+    assert result.error.code == ToolErrorCode.DEPENDENCY_ERROR
+    assert "chronos-forecasting" in result.error.message
+    assert "ts-agents[foundation]" in result.error.message
+
+
+def test_autoresearch_foundation_chronos_smoke_full_profile_stays_single_smoke(
+    monkeypatch, capsys, tmp_path
+):
+    import ts_agents.autoresearch.executor as executor_module
+    import ts_agents.autoresearch.runner as runner_module
+
+    monkeypatch.setattr(executor_module, "find_spec", lambda _name: object())
+    monkeypatch.setattr(
+        runner_module,
+        "_forecast_with_chronos",
+        lambda _model_id, series, *, horizon: np.full(horizon, float(series[-1])),
+    )
+    output_dir = tmp_path / "chronos-full"
+    code = run(
+        [
+            "autoresearch",
+            "run",
+            "foundation-chronos-smoke",
+            "--profile",
+            "full",
+            "--skip-plots",
+            "--output-dir",
+            str(output_dir),
+            "--json",
+        ]
+    )
+
+    assert code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["ok"] is True
+    assert payload["result"]["data"]["trial_count"] == 1
+    manifest = json.loads((output_dir / "run_manifest.json").read_text())
+    assert manifest["options"]["max_trials"] == 1
+
+
+def test_autoresearch_foundation_chronos_smoke_fails_empty_holdout():
+    from ts_agents.autoresearch.runner import _evaluate_forecast_trial_with_runner
+
+    row = _evaluate_forecast_trial_with_runner(
+        run_id="run",
+        trial_index=1,
+        spec={
+            "series_id": "M4",
+            "phase": "holdout",
+            "origin": 3,
+            "train": np.array([1.0, 2.0, 3.0]),
+            "actual": np.array([]),
+        },
+        model="amazon/chronos-t5-tiny",
+        task="foundation-model-smoke",
+        trial_id_prefix="foundation-chronos",
+        forecast_runner=lambda _model, _series, *, horizon: np.ones(horizon),
+        horizon=18,
+    )
+
+    assert row["status"] == "failed"
+    assert "no actual holdout values" in row["error"]
 
 
 def test_autoresearch_run_foundation_gpu_plan_materializes_plan_only_recipes(
@@ -507,6 +678,9 @@ def test_daytona_extras_context_isolated_between_loops():
     classify_context = _context_with_loop_environment(
         context, get_loop("classify-daytona"), SandboxMode.DAYTONA
     )
+    foundation_context = _context_with_loop_environment(
+        context, get_loop("foundation-chronos-smoke"), SandboxMode.DAYTONA
+    )
 
     assert context.environment == {"TS_AGENTS_DAYTONA_INSTALL_EXTRAS": "previous"}
     assert (
@@ -516,6 +690,10 @@ def test_daytona_extras_context_isolated_between_loops():
     assert (
         classify_context.environment["TS_AGENTS_DAYTONA_INSTALL_EXTRAS"]
         == "classification"
+    )
+    assert (
+        foundation_context.environment["TS_AGENTS_DAYTONA_INSTALL_EXTRAS"]
+        == "foundation"
     )
 
 

--- a/tests/cli/test_params.py
+++ b/tests/cli/test_params.py
@@ -15,6 +15,26 @@ from ts_agents.cli.main import (
 )
 
 
+def test_agent_run_simple_json_uses_agent_run_payload(monkeypatch, capsys):
+    import ts_agents.agents.simple.agent as simple_agent
+
+    monkeypatch.setattr(simple_agent, "run_single_query", lambda **_kwargs: "simple ok")
+
+    code = run(["agent", "run", "--type", "simple", "hello", "--json"])
+
+    assert code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["ok"] is True
+    assert payload["quality_status"] == "ok"
+    result = payload["result"]
+    assert result["kind"] == "agent_run"
+    assert result["status"] == "ok"
+    assert result["response"] == "simple ok"
+    assert result["data"]["response"] == "simple ok"
+    assert result["data"]["quality_flags"] == []
+    assert result["warnings"] == []
+
+
 def test_parse_list_ints_from_csv():
     assert _parse_param_value("1,2,3", "list[int]") == [1, 2, 3]
 

--- a/tests/cli/test_sandbox.py
+++ b/tests/cli/test_sandbox.py
@@ -1,7 +1,10 @@
+import importlib
 import json
 
 from ts_agents.cli.main import run
 from ts_agents.tools.executor import ExecutionResult, ExecutionStatus, ToolError, ToolErrorCode
+
+cli_main = importlib.import_module("ts_agents.cli.main")
 
 
 def test_sandbox_list_json_returns_envelope(capsys):
@@ -34,6 +37,20 @@ def test_capabilities_json_returns_bootstrap_surface(capsys):
     assert "current_profile" in install_profile
     assert install_profile["recommended_install"] == "ts-agents[recommended]"
     assert "forecasting" in install_profile["extras"]
+    assert "foundation" in install_profile["profiles"]["all"]["extras"]
+
+
+def test_detect_install_profile_requires_foundation_for_all(monkeypatch):
+    def fake_module_is_available(module_name):
+        return module_name not in {"chronos", "torch"}
+
+    monkeypatch.setattr(cli_main, "_module_is_available", fake_module_is_available)
+
+    install_profile = cli_main._detect_install_profile()
+
+    assert install_profile["current_profile"] == "recommended"
+    assert install_profile["extras"]["foundation"]["available"] is False
+    assert "foundation" in install_profile["profiles"]["all"]["extras"]
 
 
 def test_capabilities_text_reports_install_profile_on_its_own_line(capsys):

--- a/tests/test_package_metadata.py
+++ b/tests/test_package_metadata.py
@@ -49,4 +49,6 @@ def test_project_metadata_defines_dependency_extras():
     assert not any(dep.startswith("statsforecast") for dep in dependencies)
     assert not any(dep.startswith("chronos-forecasting") for dep in dependencies)
     assert any(dep.startswith("chronos-forecasting") for dep in extras["foundation"])
+    assert any(dep.startswith("torch") for dep in extras["foundation"])
+    assert set(extras["foundation"]).issubset(set(extras["all"]))
     assert project["scripts"]["ts-agents-ui"] == "ts_agents.ui.entrypoint:main"

--- a/tests/test_package_metadata.py
+++ b/tests/test_package_metadata.py
@@ -40,10 +40,13 @@ def test_project_metadata_defines_dependency_extras():
     assert "decomposition" in extras
     assert "patterns" in extras
     assert "classification" in extras
+    assert "foundation" in extras
     assert "recommended" in extras
     assert "all" in extras
 
     assert not any(dep.startswith("gradio") for dep in dependencies)
     assert not any(dep.startswith("langchain>=") for dep in dependencies)
     assert not any(dep.startswith("statsforecast") for dep in dependencies)
+    assert not any(dep.startswith("chronos-forecasting") for dep in dependencies)
+    assert any(dep.startswith("chronos-forecasting") for dep in extras["foundation"])
     assert project["scripts"]["ts-agents-ui"] == "ts_agents.ui.entrypoint:main"

--- a/ts_agents/agents/__init__.py
+++ b/ts_agents/agents/__init__.py
@@ -10,6 +10,7 @@ _LAZY_EXPORTS = {
     "create_deep_agent": ("deep", "create_deep_agent"),
     "DeepAgentChat": ("deep", "DeepAgentChat"),
     "list_subagents": ("deep", "list_subagents"),
+    "get_deep_agent_runtime_status": ("deep", "get_deep_agent_runtime_status"),
     "AgentBenchmark": ("benchmarks", "AgentBenchmark"),
     "BenchmarkResult": ("benchmarks", "BenchmarkResult"),
 }
@@ -29,6 +30,7 @@ __all__ = [
     "create_deep_agent",
     "DeepAgentChat",
     "list_subagents",
+    "get_deep_agent_runtime_status",
 
     # Benchmarks
     "AgentBenchmark",

--- a/ts_agents/agents/deep/__init__.py
+++ b/ts_agents/agents/deep/__init__.py
@@ -14,6 +14,7 @@ _LAZY_EXPORTS = {
     "run_with_approval": ("orchestrator", "run_with_approval"),
     "get_all_subagents": ("orchestrator", "get_all_subagents"),
     "create_interrupt_config": ("orchestrator", "create_interrupt_config"),
+    "get_deep_agent_runtime_status": ("orchestrator", "get_deep_agent_runtime_status"),
     "DECOMPOSITION_SUBAGENT": ("subagents", "DECOMPOSITION_SUBAGENT"),
     "FORECASTING_SUBAGENT": ("subagents", "FORECASTING_SUBAGENT"),
     "PATTERNS_SUBAGENT": ("subagents", "PATTERNS_SUBAGENT"),
@@ -42,6 +43,7 @@ __all__ = [
     "run_with_approval",
     "get_all_subagents",
     "create_interrupt_config",
+    "get_deep_agent_runtime_status",
 
     # Subagent definitions
     "DECOMPOSITION_SUBAGENT",

--- a/ts_agents/agents/deep/orchestrator.py
+++ b/ts_agents/agents/deep/orchestrator.py
@@ -23,12 +23,13 @@ import logging
 import time
 from dataclasses import dataclass, field
 from datetime import datetime
+from importlib.util import find_spec
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, Union
+from typing import Any, Callable, Dict, List, Optional
 
 from ...config import get_openai_model, get_results_cache_dir
-from ...tools.registry import ToolRegistry, ComputationalCost, _COST_ORDER
-from ...tools.bundles import get_bundle, get_subagent_bundle
+from ...tools.registry import ToolRegistry, ComputationalCost
+from ...tools.bundles import get_bundle
 from ...tools.wrappers import wrap_tools_for_deepagent
 
 from .subagents import (
@@ -46,6 +47,15 @@ from .subagents.turbulence import get_turbulence_tools
 
 
 logger = logging.getLogger(__name__)
+
+DEEPAGENTS_INSTALL_HINT = (
+    "Install deepagents to enable real sub-agent delegation: "
+    "pip install deepagents"
+)
+DEEPAGENTS_COMPATIBILITY_HINT = (
+    "deepagents is installed but could not initialize; check the installed "
+    "deepagents version and middleware API compatibility."
+)
 
 
 # =============================================================================
@@ -157,6 +167,30 @@ def create_interrupt_config(enable_approval: bool = True) -> Optional[Dict[str, 
         return None
 
     return {tool_name: True for tool_name in expensive_tools}
+
+
+def _module_available(module_name: str) -> bool:
+    try:
+        return find_spec(module_name) is not None
+    except (ModuleNotFoundError, ValueError):
+        return False
+
+
+def get_deep_agent_runtime_status() -> Dict[str, Any]:
+    """Return the runtime mode that a requested deep agent will use."""
+    missing_dependencies = []
+    if not _module_available("deepagents"):
+        missing_dependencies.append("deepagents")
+
+    fallback_used = bool(missing_dependencies)
+    return {
+        "requested_agent_type": "deep",
+        "agent_type": "deep_fallback" if fallback_used else "deep",
+        "runtime": "langchain" if fallback_used else "deepagents",
+        "fallback_used": fallback_used,
+        "missing_dependencies": missing_dependencies,
+        "install_hint": DEEPAGENTS_INSTALL_HINT if fallback_used else None,
+    }
 
 
 # =============================================================================
@@ -274,9 +308,14 @@ def create_deep_agent(
             workspace_dir=workspace_dir,
             enable_logging=enable_logging,
         )
-    except ImportError:
+    except ImportError as exc:
+        fallback_status = get_deep_agent_runtime_status()
+        fallback_status["fallback_reason"] = str(exc)
+        if not fallback_status.get("missing_dependencies"):
+            fallback_status["install_hint"] = DEEPAGENTS_COMPATIBILITY_HINT
         logger.warning(
-            "deepagents not available, falling back to LangChain-based implementation"
+            "deepagents runtime unavailable, falling back to LangChain-based implementation: %s",
+            exc,
         )
         return _create_with_langchain(
             model_name=model_name,
@@ -285,6 +324,7 @@ def create_deep_agent(
             system_prompt=system_prompt,
             enable_approval=enable_approval,
             enable_logging=enable_logging,
+            fallback_status=fallback_status,
         )
 
 
@@ -317,6 +357,10 @@ def _create_with_deepagents(
     # Store metadata
     agent._ts_agents_metadata = {
         "agent_type": "deep",
+        "runtime": "deepagents",
+        "fallback_used": False,
+        "missing_dependencies": [],
+        "install_hint": None,
         "model_name": model_name,
         "subagent_count": len(subagents),
         "subagent_names": [s["name"] for s in subagents],
@@ -341,6 +385,7 @@ def _create_with_langchain(
     system_prompt: str,
     enable_approval: bool,
     enable_logging: bool,
+    fallback_status: Optional[Dict[str, Any]] = None,
 ) -> Any:
     """Create agent using LangChain as fallback.
 
@@ -403,8 +448,20 @@ direct tool access. All sub-agent tools are available directly.
     )
 
     # Store metadata
+    if fallback_status is None:
+        fallback_status = {
+            **get_deep_agent_runtime_status(),
+            "fallback_reason": "deepagents runtime unavailable",
+        }
+        if not fallback_status.get("missing_dependencies"):
+            fallback_status["install_hint"] = DEEPAGENTS_COMPATIBILITY_HINT
     agent._ts_agents_metadata = {
         "agent_type": "deep_fallback",
+        "runtime": "langchain",
+        "fallback_used": True,
+        "fallback_reason": fallback_status.get("fallback_reason"),
+        "missing_dependencies": fallback_status.get("missing_dependencies", []),
+        "install_hint": fallback_status.get("install_hint"),
         "model_name": model_name,
         "subagent_count": len(subagents),
         "subagent_names": [s["name"] for s in subagents],
@@ -506,7 +563,7 @@ class DeepAgentChat:
         str
             The agent's response
         """
-        from langchain_core.messages import HumanMessage, AIMessage
+        from langchain_core.messages import HumanMessage
 
         start_time = time.time()
         tool_calls_before = len(self._tool_calls)

--- a/ts_agents/agents/deep/orchestrator.py
+++ b/ts_agents/agents/deep/orchestrator.py
@@ -308,13 +308,14 @@ def create_deep_agent(
             workspace_dir=workspace_dir,
             enable_logging=enable_logging,
         )
-    except ImportError as exc:
+    except Exception as exc:
         fallback_status = get_deep_agent_runtime_status()
         fallback_status["fallback_reason"] = str(exc)
         if not fallback_status.get("missing_dependencies"):
             fallback_status["install_hint"] = DEEPAGENTS_COMPATIBILITY_HINT
         logger.warning(
-            "deepagents runtime unavailable, falling back to LangChain-based implementation: %s",
+            "deepagents runtime unavailable or incompatible, "
+            "falling back to LangChain-based implementation: %s",
             exc,
         )
         return _create_with_langchain(

--- a/ts_agents/autoresearch/executor.py
+++ b/ts_agents/autoresearch/executor.py
@@ -29,7 +29,7 @@ from ts_agents.tools.executor import (
 )
 from ts_agents.tools.results import format_result, serialize_result
 
-from .registry import get_loop
+from .registry import FOUNDATION_CHRONOS_INSTALL_HINT, FOUNDATION_CHRONOS_LOOP_NAME, get_loop
 from .runner import run_autoresearch_loop
 
 _AUTORESEARCH_PREFIX = "autoresearch:"
@@ -116,18 +116,35 @@ def _autoresearch_availability(
             missing.append("aeon")
         if find_spec("sklearn") is None:
             missing.append("scikit-learn")
+    if loop_definition.name == FOUNDATION_CHRONOS_LOOP_NAME and not options.get("dry_run"):
+        if find_spec("chronos") is None:
+            missing.append("chronos-forecasting")
+        if find_spec("torch") is None:
+            missing.append("torch")
     if not missing:
         return {"available": True, "missing": []}
-    extra = (
-        "forecasting"
-        if loop_definition.name == "forecast-daytona"
-        else "classification"
-    )
+    if loop_definition.name == FOUNDATION_CHRONOS_LOOP_NAME:
+        install_hint = (
+            f"Autoresearch loop {loop_definition.name!r} requires optional "
+            "foundation-model dependencies: "
+            f"{', '.join(missing)}. Install with: "
+            f"{FOUNDATION_CHRONOS_INSTALL_HINT}"
+        )
+    else:
+        extra = (
+            "forecasting"
+            if loop_definition.name == "forecast-daytona"
+            else "classification"
+        )
+        install_hint = (
+            f"Autoresearch loop {loop_definition.name!r} requires optional "
+            f"dependencies: {', '.join(missing)}. Install with: "
+            f"pip install 'ts-agents[{extra}]'"
+        )
     return {
         "available": False,
         "missing": missing,
-        "install_hint": f"Autoresearch loop {loop_definition.name!r} requires optional dependencies: "
-        f"{', '.join(missing)}. Install with: pip install 'ts-agents[{extra}]'",
+        "install_hint": install_hint,
     }
 
 

--- a/ts_agents/autoresearch/registry.py
+++ b/ts_agents/autoresearch/registry.py
@@ -35,6 +35,18 @@ class AutoresearchLoopDefinition:
     capabilities: dict[str, Any] = field(default_factory=dict)
 
 
+FOUNDATION_CHRONOS_LOOP_NAME = "foundation-chronos-smoke"
+FOUNDATION_CHRONOS_MODEL = "amazon/chronos-t5-tiny"
+FOUNDATION_CHRONOS_TASK = "foundation-model-smoke"
+FOUNDATION_CHRONOS_HORIZON = 18
+FOUNDATION_CHRONOS_SEASON_LENGTH = 12
+FOUNDATION_CHRONOS_DEFAULT_SERIES = ["M4"]
+FOUNDATION_CHRONOS_MODEL_SCOPE = "single_chronos_zero_shot_smoke"
+FOUNDATION_CHRONOS_MODEL_SCOPE_LABEL = "single Chronos-family zero-shot smoke path"
+FOUNDATION_CHRONOS_INSTALL_HINT = "pip install 'ts-agents[foundation]'"
+FOUNDATION_CHRONOS_EXTERNAL_CONTEXT = "benchmarks/external/gift_eval_snapshot.json"
+
+
 _DAYTONA_BUDGET = AutoresearchBudget(
     timeout_seconds=20 * 60,
     vcpu=4,
@@ -102,6 +114,45 @@ _LOOPS: dict[str, AutoresearchLoopDefinition] = {
             "max_trials_semantics": "number of model/evaluation-spec rows",
             "search_style": "benchmark sweep with per-classifier window-size selection",
             "ranking_rule": "highest balanced accuracy from window-selection CV; smaller selected window and more retained windows are tie-breakers",
+        },
+    ),
+    FOUNDATION_CHRONOS_LOOP_NAME: AutoresearchLoopDefinition(
+        name=FOUNDATION_CHRONOS_LOOP_NAME,
+        task=FOUNDATION_CHRONOS_TASK,
+        description=(
+            "Run a scoped Chronos zero-shot forecasting smoke check on the vendored "
+            "M4 Monthly mini panel. This is an executable TSFM path, not a model hub."
+        ),
+        dataset="data/m4_monthly_mini.csv",
+        models=[FOUNDATION_CHRONOS_MODEL],
+        primary_metric="smape",
+        secondary_metrics=["mae", "rmse", "elapsed_seconds"],
+        budget=AutoresearchBudget(
+            timeout_seconds=30 * 60,
+            vcpu=4,
+            memory_mb=16 * 1024,
+            disk_mb=20 * 1024,
+            max_trials=1,
+            notes=[
+                "Executes only a single Chronos-family zero-shot path by default.",
+                "Dry runs do not require heavy foundation-model dependencies.",
+                "Executable runs lazy-import chronos-forecasting and torch.",
+            ],
+        ),
+        required_extras=["foundation"],
+        capabilities={
+            "status": "executable_optional_dependency",
+            "generates_metrics": True,
+            "model_scope": FOUNDATION_CHRONOS_MODEL_SCOPE,
+            "model_scope_label": FOUNDATION_CHRONOS_MODEL_SCOPE_LABEL,
+            "install_hint": FOUNDATION_CHRONOS_INSTALL_HINT,
+            "horizon": FOUNDATION_CHRONOS_HORIZON,
+            "season_length": FOUNDATION_CHRONOS_SEASON_LENGTH,
+            "default_series": FOUNDATION_CHRONOS_DEFAULT_SERIES,
+            "max_trials_semantics": "number of Chronos zero-shot forecast rows",
+            "search_style": "smoke check",
+            "ranking_rule": "lowest sMAPE on the M4 mini holdout; MAE and RMSE are tie-breakers",
+            "external_benchmark_context": FOUNDATION_CHRONOS_EXTERNAL_CONTEXT,
         },
     ),
     "foundation-gpu-plan": AutoresearchLoopDefinition(

--- a/ts_agents/autoresearch/runner.py
+++ b/ts_agents/autoresearch/runner.py
@@ -484,6 +484,7 @@ def _run_foundation_gpu_plan(**kwargs: Any) -> dict[str, Any]:
         },
     )
 
+
 def _run_foundation_chronos_smoke(**kwargs: Any) -> dict[str, Any]:
     output_path: Path = kwargs["output_path"]
     run_id: str = kwargs["run_id"]
@@ -747,6 +748,7 @@ def _forecast_trial_specs(
         )
     return specs
 
+
 def _rolling_origins(train_length: int, horizon: int, n_origins: int) -> list[int]:
     if n_origins <= 0 or train_length < horizon * 2:
         return []
@@ -859,6 +861,7 @@ def _forecast_with_method(method: str, series: np.ndarray, *, horizon: int, seas
         func_map[method](series, horizon=horizon, season_length=season_length).forecast,
         dtype=float,
     )
+
 
 def _forecast_with_chronos(model_id: str, series: np.ndarray, *, horizon: int) -> np.ndarray:
     try:

--- a/ts_agents/autoresearch/runner.py
+++ b/ts_agents/autoresearch/runner.py
@@ -11,7 +11,8 @@ import signal
 import stat
 import threading
 import time
-from typing import Any, Iterable, Optional
+from functools import lru_cache
+from typing import Any, Callable, Iterable, Optional
 
 import numpy as np
 import pandas as pd
@@ -29,7 +30,14 @@ from ts_agents.workflows.common import (
     output_dir_has_files,
 )
 
-from .registry import get_loop, loop_to_dict
+from .registry import (
+    FOUNDATION_CHRONOS_INSTALL_HINT,
+    FOUNDATION_CHRONOS_LOOP_NAME,
+    FOUNDATION_CHRONOS_MODEL,
+    FOUNDATION_CHRONOS_TASK,
+    get_loop,
+    loop_to_dict,
+)
 
 
 DEFAULT_FORECAST_SERIES = ["M4", "M10", "M100", "M1000", "M1002"]
@@ -103,6 +111,8 @@ def run_autoresearch_loop(
         return _run_classify_daytona(**common)
     if loop_name == "foundation-gpu-plan":
         return _run_foundation_gpu_plan(**common)
+    if loop_name == FOUNDATION_CHRONOS_LOOP_NAME:
+        return _run_foundation_chronos_smoke(**common)
     raise ValueError(
         f"Autoresearch loop '{loop_name}' is registered but has no runner."
     )
@@ -474,6 +484,156 @@ def _run_foundation_gpu_plan(**kwargs: Any) -> dict[str, Any]:
         },
     )
 
+def _run_foundation_chronos_smoke(**kwargs: Any) -> dict[str, Any]:
+    output_path: Path = kwargs["output_path"]
+    run_id: str = kwargs["run_id"]
+    definition = kwargs["definition"]
+    started_at: str = kwargs["started_at"]
+    profile: str = kwargs["profile"]
+    models: list[str] = kwargs["models"]
+    max_trials: int = kwargs["max_trials"]
+    timeout_seconds: int = kwargs["timeout_seconds"]
+    dry_run: bool = kwargs["dry_run"]
+    skip_plots: bool = kwargs["skip_plots"]
+
+    capabilities = definition.capabilities
+    dataset_path = _resolve_runtime_file(definition.dataset)
+    panel = _load_m4_panel(dataset_path)
+    series_ids = [
+        str(series_id)
+        for series_id in capabilities.get("default_series", [])
+        if str(series_id) in panel
+    ]
+    horizon = int(capabilities["horizon"])
+    trial_specs = _forecast_trial_specs(
+        panel=panel,
+        series_ids=series_ids,
+        horizon=horizon,
+        rolling_origins=0,
+    )
+    trial_pairs = _forecast_trial_pairs(trial_specs, models)[:max_trials]
+
+    warnings: list[str] = []
+    trials: list[dict[str, Any]] = []
+    start = time.monotonic()
+    for trial_index, (spec, model) in enumerate(trial_pairs, start=1):
+        if _budget_exhausted(start, timeout_seconds):
+            warnings.append(
+                f"Stopped before Chronos trial {trial_index}; timeout budget exhausted."
+            )
+            break
+        if dry_run:
+            trials.append(
+                _planned_trial_row(
+                    run_id, trial_index, FOUNDATION_CHRONOS_TASK, spec, model
+                )
+            )
+            continue
+        trial_timeout = _trial_timeout_for_next(
+            start,
+            timeout_seconds,
+            max_trials=max_trials,
+            completed_trials=len(trials),
+        )
+        with _trial_timeout(trial_timeout):
+            trials.append(
+                _evaluate_forecast_trial_with_runner(
+                    run_id=run_id,
+                    trial_index=trial_index,
+                    spec=spec,
+                    model=model,
+                    task=FOUNDATION_CHRONOS_TASK,
+                    trial_id_prefix="foundation-chronos",
+                    forecast_runner=lambda selected_model, train, *, horizon: _forecast_with_chronos(
+                        selected_model,
+                        train,
+                        horizon=horizon,
+                    ),
+                    horizon=horizon,
+                    extra_fields={
+                        "foundation_family": "Chronos",
+                        "execution_mode": "zero_shot",
+                    },
+                )
+            )
+
+    ranking = _rank_forecast_trials(trials)
+    warnings.extend(_forecast_ranking_warnings(trials))
+    best_config = ranking[0] if ranking else {}
+    status = (
+        "degraded"
+        if warnings or any(row.get("status") == "failed" for row in trials)
+        else "ok"
+    )
+    plot_artifacts = _write_optional_plot(
+        _write_forecast_plot,
+        output_path,
+        trials,
+        warnings,
+        enabled=not skip_plots and not dry_run,
+    )
+    options = {
+        "profile": profile,
+        "models": models,
+        "max_trials": max_trials,
+        "timeout_seconds": timeout_seconds,
+        "dry_run": dry_run,
+        "horizon": horizon,
+        "dataset": str(dataset_path),
+        "model_scope": capabilities["model_scope"],
+        "model_scope_label": capabilities["model_scope_label"],
+        "install_hint": capabilities["install_hint"],
+        "external_benchmark_context": capabilities["external_benchmark_context"],
+    }
+    artifacts = _write_autoresearch_artifacts(
+        output_path=output_path,
+        loop_name=FOUNDATION_CHRONOS_LOOP_NAME,
+        run_id=run_id,
+        started_at=started_at,
+        definition=loop_to_dict(definition),
+        options=options,
+        trials=trials,
+        best_config=best_config,
+        report=_foundation_chronos_report(
+            dataset_path=dataset_path,
+            models=models,
+            trials=trials,
+            ranking=ranking,
+            dry_run=dry_run,
+            capabilities=capabilities,
+        ),
+        extra_json={
+            "model_ranking": ranking,
+            "external_benchmark_context": capabilities["external_benchmark_context"],
+        },
+        status=status,
+        warnings=warnings,
+        extra_artifacts=plot_artifacts,
+    )
+
+    return _result_payload(
+        loop_name=FOUNDATION_CHRONOS_LOOP_NAME,
+        run_id=run_id,
+        status=status,
+        summary=(
+            "Foundation Chronos smoke loop completed with "
+            f"{len(trials)} zero-shot forecast rows."
+        ),
+        output_path=output_path,
+        trials=trials,
+        best_config=best_config,
+        artifacts=artifacts,
+        warnings=warnings,
+        started_at=started_at,
+        data_extra={
+            "ranking": ranking,
+            "dataset": str(dataset_path),
+            "model_scope": capabilities["model_scope"],
+            "model_scope_label": capabilities["model_scope_label"],
+            "external_benchmark_context": capabilities["external_benchmark_context"],
+        },
+    )
+
 def _normalize_models(loop_name: str, models: Optional[Iterable[str]]) -> list[str]:
     if models is None:
         if loop_name == "forecast-daytona":
@@ -482,6 +642,8 @@ def _normalize_models(loop_name: str, models: Optional[Iterable[str]]) -> list[s
             return list(DEFAULT_CLASSIFIERS)
         if loop_name == "foundation-gpu-plan":
             return list(DEFAULT_FOUNDATION_MODELS)
+        if loop_name == FOUNDATION_CHRONOS_LOOP_NAME:
+            return [FOUNDATION_CHRONOS_MODEL]
         return []
     normalized = []
     for model in models:
@@ -496,6 +658,7 @@ def _normalize_models(loop_name: str, models: Optional[Iterable[str]]) -> list[s
         "forecast-daytona": set(DEFAULT_FORECAST_METHODS),
         "classify-daytona": set(DEFAULT_CLASSIFIERS),
         "foundation-gpu-plan": set(DEFAULT_FOUNDATION_MODELS),
+        FOUNDATION_CHRONOS_LOOP_NAME: {FOUNDATION_CHRONOS_MODEL},
     }.get(loop_name)
     if valid is not None:
         invalid = sorted(set(normalized).difference(valid))
@@ -584,7 +747,6 @@ def _forecast_trial_specs(
         )
     return specs
 
-
 def _rolling_origins(train_length: int, horizon: int, n_origins: int) -> list[int]:
     if n_origins <= 0 or train_length < horizon * 2:
         return []
@@ -614,25 +776,57 @@ def _evaluate_forecast_trial(
     horizon: int,
     season_length: int,
 ) -> dict[str, Any]:
+    return _evaluate_forecast_trial_with_runner(
+        run_id=run_id,
+        trial_index=trial_index,
+        spec=spec,
+        model=model,
+        task="forecasting",
+        trial_id_prefix="forecast",
+        forecast_runner=lambda selected_model, train, *, horizon: _forecast_with_method(
+            selected_model,
+            train,
+            horizon=horizon,
+            season_length=season_length,
+        ),
+        horizon=horizon,
+    )
+
+
+def _evaluate_forecast_trial_with_runner(
+    *,
+    run_id: str,
+    trial_index: int,
+    spec: dict[str, Any],
+    model: str,
+    task: str,
+    trial_id_prefix: str,
+    forecast_runner: Callable[..., np.ndarray],
+    horizon: int,
+    extra_fields: Optional[dict[str, Any]] = None,
+) -> dict[str, Any]:
     actual = np.asarray(spec["actual"], dtype=float)
     started = time.monotonic()
+    safe_model_name = model.split("/")[-1] if "/" in model else model
     row = {
         "run_id": run_id,
-        "trial_id": f"forecast-{trial_index:03d}-{model}",
+        "trial_id": f"{trial_id_prefix}-{trial_index:03d}-{safe_model_name}",
         "trial_index": trial_index,
-        "task": "forecasting",
+        "task": task,
         "dataset": "m4_monthly_mini",
         "series_id": spec["series_id"],
         "phase": spec["phase"],
         "origin": spec["origin"],
         "model": model,
     }
+    row.update(extra_fields or {})
     try:
-        forecast = _forecast_with_method(
+        if actual.size == 0:
+            raise ValueError("Forecast trial has no actual holdout values to score.")
+        forecast = forecast_runner(
             model,
             np.asarray(spec["train"], dtype=float),
             horizon=horizon,
-            season_length=season_length,
         )[: len(actual)]
         metrics = _forecast_metrics(actual, forecast)
         row.update(metrics)
@@ -664,6 +858,49 @@ def _forecast_with_method(method: str, series: np.ndarray, *, horizon: int, seas
     return np.asarray(
         func_map[method](series, horizon=horizon, season_length=season_length).forecast,
         dtype=float,
+    )
+
+def _forecast_with_chronos(model_id: str, series: np.ndarray, *, horizon: int) -> np.ndarray:
+    try:
+        import torch
+    except ModuleNotFoundError as exc:
+        raise ImportError(
+            "foundation-chronos-smoke requires chronos-forecasting and torch. "
+            f"Install with: {FOUNDATION_CHRONOS_INSTALL_HINT}"
+        ) from exc
+
+    pipeline = _chronos_pipeline(model_id)
+    context = torch.tensor(series, dtype=torch.float32)
+    with torch.no_grad():
+        prediction = pipeline.predict(context, prediction_length=horizon)
+    values = prediction.detach().cpu().numpy() if hasattr(prediction, "detach") else np.asarray(prediction)
+    if values.ndim == 3:
+        values = values[0]
+    if values.ndim == 2:
+        values = np.median(values, axis=0)
+    values = np.asarray(values, dtype=float).reshape(-1)
+    if values.size < horizon:
+        raise ValueError(
+            f"Chronos prediction returned {values.size} values for horizon {horizon}."
+        )
+    return values[:horizon]
+
+
+@lru_cache(maxsize=4)
+def _chronos_pipeline(model_id: str) -> Any:
+    try:
+        import torch
+        from chronos import ChronosPipeline
+    except ModuleNotFoundError as exc:
+        raise ImportError(
+            "foundation-chronos-smoke requires chronos-forecasting and torch. "
+            f"Install with: {FOUNDATION_CHRONOS_INSTALL_HINT}"
+        ) from exc
+
+    return ChronosPipeline.from_pretrained(
+        model_id,
+        device_map="cpu",
+        torch_dtype=torch.float32,
     )
 
 
@@ -1205,6 +1442,36 @@ def _forecast_report(
         lines.extend(_markdown_table(ranking, ["model", "smape", "mae", "rmse", "n_trials"]))
     else:
         lines.append("No completed model trials were available for ranking.")
+    lines.extend(["", "## Trial Count", "", f"- rows: `{len(trials)}`", ""])
+    return "\n".join(lines)
+
+
+def _foundation_chronos_report(
+    *,
+    dataset_path: Path,
+    models: list[str],
+    trials: list[dict[str, Any]],
+    ranking: list[dict[str, Any]],
+    dry_run: bool,
+    capabilities: dict[str, Any],
+) -> str:
+    lines = [
+        "# Foundation Chronos Smoke",
+        "",
+        f"- dataset: `{dataset_path}`",
+        f"- models: `{', '.join(models)}`",
+        f"- mode: `{'dry-run' if dry_run else 'executed'}`",
+        f"- scope: {capabilities['model_scope_label']}, not a model hub",
+        "- primary metric: `sMAPE` (lower is better)",
+        f"- external context: `{capabilities['external_benchmark_context']}`",
+        "",
+        "## Ranking",
+        "",
+    ]
+    if ranking:
+        lines.extend(_markdown_table(ranking, ["model", "smape", "mae", "rmse", "n_trials"]))
+    else:
+        lines.append("No completed Chronos trials were available for ranking.")
     lines.extend(["", "## Trial Count", "", f"- rows: `{len(trials)}`", ""])
     return "\n".join(lines)
 

--- a/ts_agents/cli/main.py
+++ b/ts_agents/cli/main.py
@@ -87,6 +87,7 @@ _INSTALL_PROFILE_GROUPS: Dict[str, List[str]] = {
         "forecasting",
         "decomposition",
         "patterns",
+        "foundation",
     ],
 }
 

--- a/ts_agents/cli/main.py
+++ b/ts_agents/cli/main.py
@@ -63,6 +63,11 @@ _INSTALL_EXTRA_METADATA: Dict[str, Dict[str, Any]] = {
         "dependencies": ["aeon", "sklearn"],
         "description": "Activity-recognition and classifier evaluation workflows.",
     },
+    "foundation": {
+        "install_spec": "ts-agents[foundation]",
+        "dependencies": ["chronos", "torch"],
+        "description": "Scoped Chronos foundation-model smoke checks.",
+    },
 }
 
 _INSTALL_PROFILE_GROUPS: Dict[str, List[str]] = {
@@ -1586,6 +1591,7 @@ def _add_autoresearch_subcommands(subparsers: argparse._SubParsersAction) -> Non
             "  ts-agents autoresearch show forecast-daytona --json\n"
             "  ts-agents autoresearch run forecast-daytona --models seasonal_naive --profile smoke --json\n"
             "  ts-agents autoresearch run classify-daytona --dataset synthetic --profile smoke --json\n"
+            "  ts-agents autoresearch run foundation-chronos-smoke --dry-run --json\n"
             "  ts-agents autoresearch run foundation-gpu-plan --json"
         ),
     )
@@ -2729,6 +2735,29 @@ def _approval_prompt(tool_name: str) -> bool:
     return response in {"y", "yes"}
 
 
+def _agent_run_payload(
+    *,
+    response: str,
+    agent_metadata: Dict[str, Any],
+    warnings: Optional[List[str]] = None,
+    quality_flags: Optional[List[str]] = None,
+) -> Dict[str, Any]:
+    warnings = warnings or []
+    quality_flags = quality_flags or []
+    return {
+        "kind": "agent_run",
+        "status": "degraded" if warnings else "ok",
+        "summary": "Agent prompt completed.",
+        "response": response,
+        "data": {
+            "response": response,
+            "agent_metadata": agent_metadata,
+            "quality_flags": quality_flags,
+        },
+        "warnings": warnings,
+    }
+
+
 def _handle_agent_command(args: argparse.Namespace) -> Tuple[Any, Optional[str]]:
     if args.type == "simple":
         from ts_agents.agents.simple.agent import run_single_query
@@ -2738,7 +2767,15 @@ def _handle_agent_command(args: argparse.Namespace) -> Tuple[Any, Optional[str]]
             tool_bundle=args.tool_bundle,
             model_name=args.model,
         )
-        return {"response": response}, response
+        result = _agent_run_payload(
+            response=response,
+            agent_metadata={
+                "agent_type": "simple",
+                "tool_bundle": args.tool_bundle,
+                "model_name": args.model,
+            },
+        )
+        return result, response
 
     from ts_agents.agents.deep.orchestrator import create_deep_agent, run_with_approval
 
@@ -2757,7 +2794,31 @@ def _handle_agent_command(args: argparse.Namespace) -> Tuple[Any, Optional[str]]
         callback = _approval_prompt
 
     response = run_with_approval(agent, args.prompt, approval_callback=callback)
-    return {"response": response}, response
+    metadata = getattr(agent, "_ts_agents_metadata", {}) or {}
+    warnings = []
+    quality_flags = []
+    if metadata.get("fallback_used") or metadata.get("agent_type") == "deep_fallback":
+        install_hint = metadata.get("install_hint") or "Check deepagents runtime compatibility."
+        fallback_reason = metadata.get("fallback_reason")
+        warning = (
+            "Deep agent is running in LangChain fallback mode; "
+            f"sub-agent delegation is flattened. {install_hint}"
+        )
+        if fallback_reason:
+            warning = f"{warning} Reason: {fallback_reason}"
+        warnings.append(warning)
+        quality_flags.append("deep_agent_fallback")
+
+    result = _agent_run_payload(
+        response=response,
+        agent_metadata=metadata,
+        warnings=warnings,
+        quality_flags=quality_flags,
+    )
+    text = response
+    if warnings:
+        text = f"Warning: {warnings[0]}\n\n{response}"
+    return result, text
 
 
 def _handle_sandbox_command(args: argparse.Namespace) -> Tuple[Any, str]:

--- a/ts_agents/ui/components/chat.py
+++ b/ts_agents/ui/components/chat.py
@@ -6,12 +6,11 @@ This component provides a chat interface for interacting with:
 """
 
 import gradio as gr
-from typing import List, Tuple, Optional, Any
+from typing import Tuple, Optional, Any
 import base64
 import re
 from io import BytesIO
 
-from ..state import UIState
 
 
 # Agent type constants
@@ -169,13 +168,29 @@ def create_chat_tab(state: gr.State, agent_type: str = "simple"):
                 except ImportError as e:
                     error_msg = (
                         "Deep Agent requires LangChain packages. "
-                        "Please install: pip install langchain langchain-openai langchain-anthropic"
+                        "Please install: pip install langchain langchain-openai. "
+                        "Install deepagents to enable real sub-agent delegation."
                     )
                     print(f"Import error: {e}")
                     return None, {**agent_state, "error": error_msg}
                 agent = DeepAgentChat()
 
             new_state = {"agent": agent, "type": agent_type_str, "bundle": bundle}
+            metadata = getattr(getattr(agent, "agent", None), "_ts_agents_metadata", {}) or {}
+            if metadata.get("fallback_used") or metadata.get("agent_type") == "deep_fallback":
+                install_hint = metadata.get("install_hint") or "Check deepagents runtime compatibility."
+                fallback_reason = metadata.get("fallback_reason")
+                warning = (
+                    "Deep agent is running in LangChain fallback mode; "
+                    f"sub-agent delegation is flattened. {install_hint}"
+                )
+                if fallback_reason:
+                    warning = f"{warning} Reason: {fallback_reason}"
+                new_state = {
+                    **new_state,
+                    "warning": warning,
+                    "warning_shown": False,
+                }
             return agent, new_state
         except Exception as e:
             print(f"Error creating agent: {e}")
@@ -235,6 +250,10 @@ def create_chat_tab(state: gr.State, agent_type: str = "simple"):
 
             # Check for image in response
             cleaned_response, img = extract_image_from_response(response)
+            runtime_warning = new_agent_state.get("warning")
+            if runtime_warning and not new_agent_state.get("warning_shown"):
+                cleaned_response = f"{runtime_warning}\n\n{cleaned_response}"
+                new_agent_state = {**new_agent_state, "warning_shown": True}
 
             history = history + [{"role": "assistant", "content": cleaned_response}]
 

--- a/uv.lock
+++ b/uv.lock
@@ -9,6 +9,25 @@ resolution-markers = [
 ]
 
 [[package]]
+name = "accelerate"
+version = "1.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "huggingface-hub" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12' and sys_platform == 'win32'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' or sys_platform != 'win32'" },
+    { name = "packaging" },
+    { name = "psutil" },
+    { name = "pyyaml" },
+    { name = "safetensors" },
+    { name = "torch" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ca/14/787e5498cd062640f0f3d92ef4ae4063174f76f9afd29d13fc52a319daae/accelerate-1.13.0.tar.gz", hash = "sha256:d631b4e0f5b3de4aff2d7e9e6857d164810dfc3237d54d017f075122d057b236", size = 402835, upload-time = "2026-03-04T19:34:12.359Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/46/02ac5e262d4af18054b3e922b2baedbb2a03289ee792162de60a865defc5/accelerate-1.13.0-py3-none-any.whl", hash = "sha256:cf1a3efb96c18f7b152eb0fa7490f3710b19c3f395699358f08decca2b8b62e0", size = 383744, upload-time = "2026-03-04T19:34:10.313Z" },
+]
+
+[[package]]
 name = "adagio"
 version = "0.2.6"
 source = { registry = "https://pypi.org/simple" }
@@ -395,6 +414,24 @@ wheels = [
 ]
 
 [[package]]
+name = "chronos-forecasting"
+version = "2.2.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "accelerate" },
+    { name = "einops" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12' and sys_platform == 'win32'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' or sys_platform != 'win32'" },
+    { name = "scikit-learn" },
+    { name = "torch" },
+    { name = "transformers" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/27/a6/b214932e9249aa0fb9638802cd2718dbe4cb2efd5118dc3ce2f02d7dfac4/chronos_forecasting-2.2.2.tar.gz", hash = "sha256:3611bc0f31fa5a77ef710a10857772f80bef20f537ee87f959b0a949dbecd8d0", size = 702413, upload-time = "2025-12-17T18:13:51.416Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/d9/ca38acd7a34c9ee6ed8bd05c2824d3fcc789a93ebdb185e56f81b89fa783/chronos_forecasting-2.2.2-py3-none-any.whl", hash = "sha256:1ff681451361f8c0a5fd6920cc1a0d8139f46c85f77a7d6d34fd554390bc76d9", size = 72663, upload-time = "2025-12-17T18:13:49.874Z" },
+]
+
+[[package]]
 name = "click"
 version = "8.2.1"
 source = { registry = "https://pypi.org/simple" }
@@ -522,6 +559,70 @@ wheels = [
 ]
 
 [[package]]
+name = "cuda-bindings"
+version = "13.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cuda-pathfinder", marker = "python_full_version >= '3.12' or sys_platform != 'win32'" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/6b/457ca12dad3ee9bfcc9a545cfd6b64b359ba49de40f776f6e028e678f262/cuda_bindings-13.3.1-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c5879712accf6e14bb01aa5e67440eb84998b8d104b509cc7a6dc0b8f656a474", size = 6053539, upload-time = "2026-05-29T23:11:43.19Z" },
+    { url = "https://files.pythonhosted.org/packages/95/7a/c5e3c34a409b148f5c0f5a4ea374158f95d488862c1dffedf9aa5c639df9/cuda_bindings-13.3.1-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:04436a9364059c84b8f9636f359eccda1cf814341f5b670c71d80d2f79dbc708", size = 6674166, upload-time = "2026-05-29T23:11:45.478Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/67/5e7dba1ba576dd73da5dee894ca076ca5e959450dfff66d6d510a255d1f7/cuda_bindings-13.3.1-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c7855c4868aabc0cfae28abbe83d56734bdfbd08f08fc234ac1912a12858bf49", size = 6025351, upload-time = "2026-05-29T23:11:49.685Z" },
+    { url = "https://files.pythonhosted.org/packages/39/2a/6d2e9047d1fb243dbaa364b01e0297534b9ed7fd27dba1c9f361519cf69b/cuda_bindings-13.3.1-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e32d08f71ebcdf00f0f41eab2eb37e8da94c8ed411cc9f7f7a019ce6b34abe3a", size = 6657965, upload-time = "2026-05-29T23:11:52.227Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/6e/2394f8163360f8391f8f1b7e72d300a82724edb81a7b7084c799fbd4c91f/cuda_bindings-13.3.1-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9efb21c1ee64981e184b9e0ba5eb3179e5ba3d4b51665a6cb52b8ef3d01a7cbf", size = 5920504, upload-time = "2026-05-29T23:11:56.883Z" },
+    { url = "https://files.pythonhosted.org/packages/34/c2/ef9b6a63f7dc432712a462c816662e662e00d38caa9b861c8c2588195d03/cuda_bindings-13.3.1-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2732904099e0a4d4db774a5fc6d91ee95fae065b4d2ecabb4968c5fe2406c9d7", size = 6476660, upload-time = "2026-05-29T23:11:59.188Z" },
+]
+
+[[package]]
+name = "cuda-pathfinder"
+version = "1.5.5"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/11/c8/26f2e4aae92f11522a96043892ba39a90eac610d5242523aa863212bc1c7/cuda_pathfinder-1.5.5-py3-none-any.whl", hash = "sha256:0228c023f95d1480f143ef5c8922d27a2ab052087a942e81dc289c9eb8f91689", size = 51671, upload-time = "2026-05-27T01:21:25.413Z" },
+]
+
+[[package]]
+name = "cuda-toolkit"
+version = "13.0.2"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/57/b2/453099f5f3b698d7d0eab38916aac44c7f76229f451709e2eb9db6615dcd/cuda_toolkit-13.0.2-py2.py3-none-any.whl", hash = "sha256:b198824cf2f54003f50d64ada3a0f184b42ca0846c1c94192fa269ecd97a66eb", size = 2364, upload-time = "2025-12-19T23:24:07.328Z" },
+]
+
+[package.optional-dependencies]
+cudart = [
+    { name = "nvidia-cuda-runtime", marker = "(python_full_version >= '3.12' and sys_platform == 'win32') or sys_platform == 'linux'" },
+]
+cufft = [
+    { name = "nvidia-cufft", marker = "(python_full_version >= '3.12' and sys_platform == 'win32') or sys_platform == 'linux'" },
+]
+cufile = [
+    { name = "nvidia-cufile", marker = "sys_platform == 'linux'" },
+]
+cupti = [
+    { name = "nvidia-cuda-cupti", marker = "(python_full_version >= '3.12' and sys_platform == 'win32') or sys_platform == 'linux'" },
+]
+curand = [
+    { name = "nvidia-curand", marker = "(python_full_version >= '3.12' and sys_platform == 'win32') or sys_platform == 'linux'" },
+]
+cusolver = [
+    { name = "nvidia-cusolver", marker = "(python_full_version >= '3.12' and sys_platform == 'win32') or sys_platform == 'linux'" },
+]
+cusparse = [
+    { name = "nvidia-cusparse", marker = "(python_full_version >= '3.12' and sys_platform == 'win32') or sys_platform == 'linux'" },
+]
+nvjitlink = [
+    { name = "nvidia-nvjitlink", marker = "(python_full_version >= '3.12' and sys_platform == 'win32') or sys_platform == 'linux'" },
+]
+nvrtc = [
+    { name = "nvidia-cuda-nvrtc", marker = "(python_full_version >= '3.12' and sys_platform == 'win32') or sys_platform == 'linux'" },
+]
+nvtx = [
+    { name = "nvidia-nvtx", marker = "(python_full_version >= '3.12' and sys_platform == 'win32') or sys_platform == 'linux'" },
+]
+
+[[package]]
 name = "cycler"
 version = "0.12.1"
 source = { registry = "https://pypi.org/simple" }
@@ -588,6 +689,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", size = 60722, upload-time = "2023-12-24T09:54:32.31Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277, upload-time = "2023-12-24T09:54:30.421Z" },
+]
+
+[[package]]
+name = "einops"
+version = "0.8.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/77/850bef8d72ffb9219f0b1aac23fbc1bf7d038ee6ea666f331fa273031aa2/einops-0.8.2.tar.gz", hash = "sha256:609da665570e5e265e27283aab09e7f279ade90c4f01bcfca111f3d3e13f2827", size = 56261, upload-time = "2026-01-26T04:13:17.638Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/09/f8d8f8f31e4483c10a906437b4ce31bdf3d6d417b73fe33f1a8b59e34228/einops-0.8.2-py3-none-any.whl", hash = "sha256:54058201ac7087911181bfec4af6091bb59380360f069276601256a76af08193", size = 65638, upload-time = "2026-01-26T04:13:18.546Z" },
 ]
 
 [[package]]
@@ -831,23 +941,21 @@ wheels = [
 
 [[package]]
 name = "huggingface-hub"
-version = "1.1.6"
+version = "0.36.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "filelock" },
     { name = "fsspec" },
-    { name = "hf-xet", marker = "platform_machine == 'AMD64' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'" },
-    { name = "httpx" },
+    { name = "hf-xet", marker = "platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'" },
     { name = "packaging" },
     { name = "pyyaml" },
-    { name = "shellingham" },
+    { name = "requests" },
     { name = "tqdm" },
-    { name = "typer-slim" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4c/08/dc669fa8c7267752ce2d536683436f0c46661aca45e9450c635a365ca2df/huggingface_hub-1.1.6.tar.gz", hash = "sha256:e1beacb611d74a8189b4c5298e8675fb518256af73b38143171f6efa7d822cf6", size = 607477, upload-time = "2025-11-28T10:23:35.223Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7c/b7/8cb61d2eece5fb05a83271da168186721c450eb74e3c31f7ef3169fa475b/huggingface_hub-0.36.2.tar.gz", hash = "sha256:1934304d2fb224f8afa3b87007d58501acfda9215b334eed53072dd5e815ff7a", size = 649782, upload-time = "2026-02-06T09:24:13.098Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c2/3c/168062db8c0068315ed3f137db450869eb14d98f00144234c118f294b461/huggingface_hub-1.1.6-py3-none-any.whl", hash = "sha256:09726c4fc4c0dc5d83568234daff1ccb815c39b310784359c9d8b5906f679de2", size = 516110, upload-time = "2025-11-28T10:23:33.63Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/af/48ac8483240de756d2438c380746e7130d1c6f75802ef22f3c6d49982787/huggingface_hub-0.36.2-py3-none-any.whl", hash = "sha256:48f0c8eac16145dfce371e9d2d7772854a4f591bcb56c9cf548accf531d54270", size = 566395, upload-time = "2026-02-06T09:24:11.133Z" },
 ]
 
 [[package]]
@@ -1682,6 +1790,15 @@ wheels = [
 ]
 
 [[package]]
+name = "mpmath"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/47/dd32fa426cc72114383ac549964eecb20ecfd886d1e5ccf5340b55b02f57/mpmath-1.3.0.tar.gz", hash = "sha256:7a28eb2a9774d00c7bc92411c19a89209d5da7c4c9a9e227be8330a23a25b91f", size = 508106, upload-time = "2023-03-07T16:47:11.061Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/e3/7d92a15f894aa0c9c4b49b8ee9ac9850d6e63b03c9c32c0367a13ae62209/mpmath-1.3.0-py3-none-any.whl", hash = "sha256:a0b2b9fe80bbcd81a6647ff13108738cfb482d481d826cc0e02f5b35e5c88d2c", size = 536198, upload-time = "2023-03-07T16:47:09.197Z" },
+]
+
+[[package]]
 name = "mypy"
 version = "1.19.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1785,6 +1902,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/83/f8/51569ac65d696c8ecbee95938f89d4abf00f47d58d48f6fbabfe8f0baefe/nest_asyncio-1.6.0.tar.gz", hash = "sha256:6f172d5449aca15afd6c646851f4e31e02c598d553a667e38cafa997cfec55fe", size = 7418, upload-time = "2024-01-21T14:25:19.227Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a0/c4/c2971a3ba4c6103a3d10c4b0f24f461ddc027f0f09763220cf35ca1401b3/nest_asyncio-1.6.0-py3-none-any.whl", hash = "sha256:87af6efd6b5e897c81050477ef65c62e2b2f35d51703cae01aff2905b1852e1c", size = 5195, upload-time = "2024-01-21T14:25:17.223Z" },
+]
+
+[[package]]
+name = "networkx"
+version = "3.6.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6a/51/63fe664f3908c97be9d2e4f1158eb633317598cfa6e1fc14af5383f17512/networkx-3.6.1.tar.gz", hash = "sha256:26b7c357accc0c8cde558ad486283728b65b6a95d85ee1cd66bafab4c8168509", size = 2517025, upload-time = "2025-12-08T17:02:39.908Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/c9/b2622292ea83fbb4ec318f5b9ab867d0a28ab43c5717bb85b0a5f6b3b0a4/networkx-3.6.1-py3-none-any.whl", hash = "sha256:d47fbf302e7d9cbbb9e2555a0d267983d2aa476bac30e90dfbe5669bd57f3762", size = 2068504, upload-time = "2025-12-08T17:02:38.159Z" },
 ]
 
 [[package]]
@@ -1914,6 +2040,158 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/76/95/bef5b37f29fc5e739947e9ce5179ad402875633308504a52d188302319c8/numpy-2.2.6-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:8e9ace4a37db23421249ed236fdcdd457d671e25146786dfc96835cd951aa7c1", size = 18385260, upload-time = "2025-05-17T21:43:05.189Z" },
     { url = "https://files.pythonhosted.org/packages/09/04/f2f83279d287407cf36a7a8053a5abe7be3622a4363337338f2585e4afda/numpy-2.2.6-cp313-cp313t-win32.whl", hash = "sha256:038613e9fb8c72b0a41f025a7e4c3f0b7a1b5d768ece4796b674c8f3fe13efff", size = 6377225, upload-time = "2025-05-17T21:43:16.254Z" },
     { url = "https://files.pythonhosted.org/packages/67/0e/35082d13c09c02c011cf21570543d202ad929d961c02a147493cb0c2bdf5/numpy-2.2.6-cp313-cp313t-win_amd64.whl", hash = "sha256:6031dd6dfecc0cf9f668681a37648373bddd6421fff6c66ec1624eed0180ee06", size = 12771374, upload-time = "2025-05-17T21:43:35.479Z" },
+]
+
+[[package]]
+name = "nvidia-cublas"
+version = "13.1.1.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-cuda-nvrtc", marker = "python_full_version >= '3.12' or sys_platform != 'win32'" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/a1/0bd24ee8c8d03adac032fd2909426a00c88f8c57961b1277ded97f91119f/nvidia_cublas-13.1.1.3-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:b7a210458267ac818974c53038fbec2e969d5c99f305ab15c72522fa9f001dd5", size = 542848918, upload-time = "2026-04-08T18:46:22.985Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/cd/154ca20c38269e05eff77c1464e6c1da89f50a6390b565e9d82e06bc11e1/nvidia_cublas-13.1.1.3-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:37936a16db8fe4ac1f065c2139360608a543a09275cb1a1af612e08cfa065436", size = 423138758, upload-time = "2026-04-08T18:46:58.655Z" },
+]
+
+[[package]]
+name = "nvidia-cuda-cupti"
+version = "13.0.85"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/2a/80353b103fc20ce05ef51e928daed4b6015db4aaa9162ed0997090fe2250/nvidia_cuda_cupti-13.0.85-py3-none-manylinux_2_25_aarch64.whl", hash = "sha256:796bd679890ee55fb14a94629b698b6db54bcfd833d391d5e94017dd9d7d3151", size = 10310827, upload-time = "2025-09-04T08:26:42.012Z" },
+    { url = "https://files.pythonhosted.org/packages/33/6d/737d164b4837a9bbd202f5ae3078975f0525a55730fe871d8ed4e3b952b0/nvidia_cuda_cupti-13.0.85-py3-none-manylinux_2_25_x86_64.whl", hash = "sha256:4eb01c08e859bf924d222250d2e8f8b8ff6d3db4721288cf35d14252a4d933c8", size = 10715597, upload-time = "2025-09-04T08:26:51.312Z" },
+]
+
+[[package]]
+name = "nvidia-cuda-nvrtc"
+version = "13.0.88"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c3/68/483a78f5e8f31b08fb1bb671559968c0ca3a065ac7acabfc7cee55214fd6/nvidia_cuda_nvrtc-13.0.88-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:ad9b6d2ead2435f11cbb6868809d2adeeee302e9bb94bcf0539c7a40d80e8575", size = 90215200, upload-time = "2025-09-04T08:28:44.204Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/dc/6bb80850e0b7edd6588d560758f17e0550893a1feaf436807d64d2da040f/nvidia_cuda_nvrtc-13.0.88-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d27f20a0ca67a4bb34268a5e951033496c5b74870b868bacd046b1b8e0c3267b", size = 43015449, upload-time = "2025-09-04T08:28:20.239Z" },
+]
+
+[[package]]
+name = "nvidia-cuda-runtime"
+version = "13.0.96"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/87/4f/17d7b9b8e285199c58ce28e31b5c5bbaa4d8271af06a89b6405258245de2/nvidia_cuda_runtime-13.0.96-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ef9bcbe90493a2b9d810e43d249adb3d02e98dd30200d86607d8d02687c43f55", size = 2261060, upload-time = "2025-10-09T08:55:15.78Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/24/d1558f3b68b1d26e706813b1d10aa1d785e4698c425af8db8edc3dced472/nvidia_cuda_runtime-13.0.96-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7f82250d7782aa23b6cfe765ecc7db554bd3c2870c43f3d1821f1d18aebf0548", size = 2243632, upload-time = "2025-10-09T08:55:36.117Z" },
+]
+
+[[package]]
+name = "nvidia-cudnn-cu13"
+version = "9.20.0.48"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-cublas", marker = "python_full_version >= '3.12' or sys_platform != 'win32'" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/56/c5/83384d846b2fd17c44bd499b36c75a45ed4f095fbbb2252294e89cea5c5c/nvidia_cudnn_cu13-9.20.0.48-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:e31454ae00094b0c55319d9d15b6fa2fc50a9e1c0f5c8c80fb75258234e731e1", size = 444574296, upload-time = "2026-03-09T19:28:27.751Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/5e/edb9c0ae051602c3ccaffe424256463636d639e27d7f302dde9975ef9e7a/nvidia_cudnn_cu13-9.20.0.48-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:0c45dd8eeb50b603f07995b1b300c62ffe6a1980482b82b3bcf94a4ca9d49304", size = 366173588, upload-time = "2026-03-09T19:29:34.474Z" },
+]
+
+[[package]]
+name = "nvidia-cufft"
+version = "12.0.0.61"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-nvjitlink", marker = "python_full_version >= '3.12' or sys_platform != 'win32'" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8b/ae/f417a75c0259e85c1d2f83ca4e960289a5f814ed0cea74d18c353d3e989d/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2708c852ef8cd89d1d2068bdbece0aa188813a0c934db3779b9b1faa8442e5f5", size = 214053554, upload-time = "2025-09-04T08:31:38.196Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/2f/7b57e29836ea8714f81e9898409196f47d772d5ddedddf1592eadb8ab743/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:6c44f692dce8fd5ffd3e3df134b6cdb9c2f72d99cf40b62c32dde45eea9ddad3", size = 214085489, upload-time = "2025-09-04T08:31:56.044Z" },
+]
+
+[[package]]
+name = "nvidia-cufile"
+version = "1.15.1.6"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/70/4f193de89a48b71714e74602ee14d04e4019ad36a5a9f20c425776e72cd6/nvidia_cufile-1.15.1.6-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:08a3ecefae5a01c7f5117351c64f17c7c62efa5fffdbe24fc7d298da19cd0b44", size = 1223672, upload-time = "2025-09-04T08:32:22.779Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/73/cc4a14c9813a8a0d509417cf5f4bdaba76e924d58beb9864f5a7baceefbf/nvidia_cufile-1.15.1.6-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:bdc0deedc61f548bddf7733bdc216456c2fdb101d020e1ab4b88d232d5e2f6d1", size = 1136992, upload-time = "2025-09-04T08:32:14.119Z" },
+]
+
+[[package]]
+name = "nvidia-curand"
+version = "10.4.0.35"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/72/7c2ae24fb6b63a32e6ae5d241cc65263ea18d08802aaae087d9f013335a2/nvidia_curand-10.4.0.35-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:133df5a7509c3e292aaa2b477afd0194f06ce4ea24d714d616ff36439cee349a", size = 61962106, upload-time = "2025-08-04T10:21:41.128Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/9f/be0a41ca4a4917abf5cb9ae0daff1a6060cc5de950aec0396de9f3b52bc5/nvidia_curand-10.4.0.35-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:1aee33a5da6e1db083fe2b90082def8915f30f3248d5896bcec36a579d941bfc", size = 59544258, upload-time = "2025-08-04T10:22:03.992Z" },
+]
+
+[[package]]
+name = "nvidia-cusolver"
+version = "12.0.4.66"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-cublas", marker = "python_full_version >= '3.12' or sys_platform != 'win32'" },
+    { name = "nvidia-cusparse", marker = "python_full_version >= '3.12' or sys_platform != 'win32'" },
+    { name = "nvidia-nvjitlink", marker = "python_full_version >= '3.12' or sys_platform != 'win32'" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c8/c3/b30c9e935fc01e3da443ec0116ed1b2a009bb867f5324d3f2d7e533e776b/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:02c2457eaa9e39de20f880f4bd8820e6a1cfb9f9a34f820eb12a155aa5bc92d2", size = 223467760, upload-time = "2025-09-04T08:33:04.222Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/67/cba3777620cdacb99102da4042883709c41c709f4b6323c10781a9c3aa34/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:0a759da5dea5c0ea10fd307de75cdeb59e7ea4fcb8add0924859b944babf1112", size = 200941980, upload-time = "2025-09-04T08:33:22.767Z" },
+]
+
+[[package]]
+name = "nvidia-cusparse"
+version = "12.6.3.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-nvjitlink", marker = "python_full_version >= '3.12' or sys_platform != 'win32'" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f8/94/5c26f33738ae35276672f12615a64bd008ed5be6d1ebcb23579285d960a9/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:80bcc4662f23f1054ee334a15c72b8940402975e0eab63178fc7e670aa59472c", size = 162155568, upload-time = "2025-09-04T08:33:42.864Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/18/623c77619c31d62efd55302939756966f3ecc8d724a14dab2b75f1508850/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2b3c89c88d01ee0e477cb7f82ef60a11a4bcd57b6b87c33f789350b59759360b", size = 145942937, upload-time = "2025-09-04T08:33:58.029Z" },
+]
+
+[[package]]
+name = "nvidia-cusparselt-cu13"
+version = "0.8.1"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/46/e1/cdc1797eadf82d3a9a575a19b33fdc871a97edbec42c00b5b5e914f4aff4/nvidia_cusparselt_cu13-0.8.1-py3-none-manylinux2014_aarch64.whl", hash = "sha256:4dca476c50bf4780d46cd0bfbd82e2bc10a08e4fef7950917ce8d7578d22a23f", size = 221051344, upload-time = "2025-09-05T18:49:51.289Z" },
+    { url = "https://files.pythonhosted.org/packages/34/7d/2661f2fb3ac4302f3a246f5fc030213ac60c1fe0bce84f9783dbd831dbb7/nvidia_cusparselt_cu13-0.8.1-py3-none-manylinux2014_x86_64.whl", hash = "sha256:786ce87568c303fadb5afcc7102d454cd3040d75f6f8626f5db460d1871f4dd0", size = 170148586, upload-time = "2025-09-05T18:50:50.248Z" },
+]
+
+[[package]]
+name = "nvidia-nccl-cu13"
+version = "2.29.7"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/72/0d/daf50d44177ee0cbc7ff0a0c91eb5ff676c82be42f9a970bc7597f440c3a/nvidia_nccl_cu13-2.29.7-py3-none-manylinux_2_18_aarch64.whl", hash = "sha256:674a12383e3c38a1bcccae7d4f3633b37852230b6047883cb2f4c2d1b36d9bf5", size = 206014712, upload-time = "2026-03-03T05:34:20.843Z" },
+    { url = "https://files.pythonhosted.org/packages/67/f4/58e4e91b6919367c7aafb8e36fce9aad1a3047e536bf7e2fd560927d3a4c/nvidia_nccl_cu13-2.29.7-py3-none-manylinux_2_18_x86_64.whl", hash = "sha256:edd81538446786ec3b73972543e53bb43bcaf0bfc8ef76cb679fcc390ffe136d", size = 205976000, upload-time = "2026-03-03T05:36:24.472Z" },
+]
+
+[[package]]
+name = "nvidia-nvjitlink"
+version = "13.0.88"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/56/7a/123e033aaff487c77107195fa5a2b8686795ca537935a24efae476c41f05/nvidia_nvjitlink-13.0.88-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:13a74f429e23b921c1109976abefacc69835f2f433ebd323d3946e11d804e47b", size = 40713933, upload-time = "2025-09-04T08:35:43.553Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/2c/93c5250e64df4f894f1cbb397c6fd71f79813f9fd79d7cd61de3f97b3c2d/nvidia_nvjitlink-13.0.88-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:e931536ccc7d467a98ba1d8b89ff7fa7f1fa3b13f2b0069118cd7f47bff07d0c", size = 38768748, upload-time = "2025-09-04T08:35:20.008Z" },
+]
+
+[[package]]
+name = "nvidia-nvshmem-cu13"
+version = "3.4.5"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/0f/05cc9c720236dcd2db9c1ab97fff629e96821be2e63103569da0c9b72f19/nvidia_nvshmem_cu13-3.4.5-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:6dc2a197f38e5d0376ad52cd1a2a3617d3cdc150fd5966f4aee9bcebb1d68fe9", size = 60215947, upload-time = "2025-09-06T00:32:20.022Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/35/a9bf80a609e74e3b000fef598933235c908fcefcef9026042b8e6dfde2a9/nvidia_nvshmem_cu13-3.4.5-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:290f0a2ee94c9f3687a02502f3b9299a9f9fe826e6d0287ee18482e78d495b80", size = 60412546, upload-time = "2025-09-06T00:32:41.564Z" },
+]
+
+[[package]]
+name = "nvidia-nvtx"
+version = "13.0.85"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/f3/d86c845465a2723ad7e1e5c36dcd75ddb82898b3f53be47ebd429fb2fa5d/nvidia_nvtx-13.0.85-py3-none-manylinux1_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:4936d1d6780fbe68db454f5e72a42ff64d1fd6397df9f363ae786930fd5c1cd4", size = 148047, upload-time = "2025-09-04T08:29:01.761Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/64/3708a90d1ebe202ffdeb7185f878a3c84d15c2b2c31858da2ce0583e2def/nvidia_nvtx-13.0.85-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:cb7780edb6b14107373c835bf8b72e7a178bac7367e23da7acb108f973f157a6", size = 148878, upload-time = "2025-09-04T08:28:53.627Z" },
 ]
 
 [[package]]
@@ -2878,6 +3156,28 @@ wheels = [
 ]
 
 [[package]]
+name = "safetensors"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/29/9c/6e74567782559a63bd040a236edca26fd71bc7ba88de2ef35d75df3bca5e/safetensors-0.7.0.tar.gz", hash = "sha256:07663963b67e8bd9f0b8ad15bb9163606cd27cc5a1b96235a50d8369803b96b0", size = 200878, upload-time = "2025-11-19T15:18:43.199Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/47/aef6c06649039accf914afef490268e1067ed82be62bcfa5b7e886ad15e8/safetensors-0.7.0-cp38-abi3-macosx_10_12_x86_64.whl", hash = "sha256:c82f4d474cf725255d9e6acf17252991c3c8aac038d6ef363a4bf8be2f6db517", size = 467781, upload-time = "2025-11-19T15:18:35.84Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/00/374c0c068e30cd31f1e1b46b4b5738168ec79e7689ca82ee93ddfea05109/safetensors-0.7.0-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:94fd4858284736bb67a897a41608b5b0c2496c9bdb3bf2af1fa3409127f20d57", size = 447058, upload-time = "2025-11-19T15:18:34.416Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/06/578ffed52c2296f93d7fd2d844cabfa92be51a587c38c8afbb8ae449ca89/safetensors-0.7.0-cp38-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e07d91d0c92a31200f25351f4acb2bc6aff7f48094e13ebb1d0fb995b54b6542", size = 491748, upload-time = "2025-11-19T15:18:09.79Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/33/1debbbb70e4791dde185edb9413d1fe01619255abb64b300157d7f15dddd/safetensors-0.7.0-cp38-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8469155f4cb518bafb4acf4865e8bb9d6804110d2d9bdcaa78564b9fd841e104", size = 503881, upload-time = "2025-11-19T15:18:16.145Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/1c/40c2ca924d60792c3be509833df711b553c60effbd91da6f5284a83f7122/safetensors-0.7.0-cp38-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:54bef08bf00a2bff599982f6b08e8770e09cc012d7bba00783fc7ea38f1fb37d", size = 623463, upload-time = "2025-11-19T15:18:21.11Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/3a/13784a9364bd43b0d61eef4bea2845039bc2030458b16594a1bd787ae26e/safetensors-0.7.0-cp38-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:42cb091236206bb2016d245c377ed383aa7f78691748f3bb6ee1bfa51ae2ce6a", size = 532855, upload-time = "2025-11-19T15:18:25.719Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/60/429e9b1cb3fc651937727befe258ea24122d9663e4d5709a48c9cbfceecb/safetensors-0.7.0-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dac7252938f0696ddea46f5e855dd3138444e82236e3be475f54929f0c510d48", size = 507152, upload-time = "2025-11-19T15:18:33.023Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/a8/4b45e4e059270d17af60359713ffd83f97900d45a6afa73aaa0d737d48b6/safetensors-0.7.0-cp38-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1d060c70284127fa805085d8f10fbd0962792aed71879d00864acda69dbab981", size = 541856, upload-time = "2025-11-19T15:18:31.075Z" },
+    { url = "https://files.pythonhosted.org/packages/06/87/d26d8407c44175d8ae164a95b5a62707fcc445f3c0c56108e37d98070a3d/safetensors-0.7.0-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:cdab83a366799fa730f90a4ebb563e494f28e9e92c4819e556152ad55e43591b", size = 674060, upload-time = "2025-11-19T15:18:37.211Z" },
+    { url = "https://files.pythonhosted.org/packages/11/f5/57644a2ff08dc6325816ba7217e5095f17269dada2554b658442c66aed51/safetensors-0.7.0-cp38-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:672132907fcad9f2aedcb705b2d7b3b93354a2aec1b2f706c4db852abe338f85", size = 771715, upload-time = "2025-11-19T15:18:38.689Z" },
+    { url = "https://files.pythonhosted.org/packages/86/31/17883e13a814bd278ae6e266b13282a01049b0c81341da7fd0e3e71a80a3/safetensors-0.7.0-cp38-abi3-musllinux_1_2_i686.whl", hash = "sha256:5d72abdb8a4d56d4020713724ba81dac065fedb7f3667151c4a637f1d3fb26c0", size = 714377, upload-time = "2025-11-19T15:18:40.162Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/d8/0c8a7dc9b41dcac53c4cbf9df2b9c83e0e0097203de8b37a712b345c0be5/safetensors-0.7.0-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b0f6d66c1c538d5a94a73aa9ddca8ccc4227e6c9ff555322ea40bdd142391dd4", size = 677368, upload-time = "2025-11-19T15:18:41.627Z" },
+    { url = "https://files.pythonhosted.org/packages/05/e5/cb4b713c8a93469e3c5be7c3f8d77d307e65fe89673e731f5c2bfd0a9237/safetensors-0.7.0-cp38-abi3-win32.whl", hash = "sha256:c74af94bf3ac15ac4d0f2a7c7b4663a15f8c2ab15ed0fc7531ca61d0835eccba", size = 326423, upload-time = "2025-11-19T15:18:45.74Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/e6/ec8471c8072382cb91233ba7267fd931219753bb43814cbc71757bfd4dab/safetensors-0.7.0-cp38-abi3-win_amd64.whl", hash = "sha256:d1239932053f56f3456f32eb9625590cc7582e905021f94636202a864d470755", size = 341380, upload-time = "2025-11-19T15:18:44.427Z" },
+]
+
+[[package]]
 name = "scikit-learn"
 version = "1.7.2"
 source = { registry = "https://pypi.org/simple" }
@@ -3140,6 +3440,18 @@ wheels = [
 ]
 
 [[package]]
+name = "sympy"
+version = "1.14.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mpmath" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/83/d3/803453b36afefb7c2bb238361cd4ae6125a569b4db67cd9e79846ba2d68c/sympy-1.14.0.tar.gz", hash = "sha256:d3d3fe8df1e5a0b42f0e7bdf50541697dbe7d23746e894990c030e2b05e72517", size = 7793921, upload-time = "2025-04-27T18:05:01.611Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a2/09/77d55d46fd61b4a135c444fc97158ef34a095e5681d0a6c10b75bf356191/sympy-1.14.0-py3-none-any.whl", hash = "sha256:e091cc3e99d2141a0ba2847328f5479b05d94a6635cb96148ccb3f34671bd8f5", size = 6299353, upload-time = "2025-04-27T18:04:59.103Z" },
+]
+
+[[package]]
 name = "tenacity"
 version = "9.1.2"
 source = { registry = "https://pypi.org/simple" }
@@ -3224,12 +3536,78 @@ wheels = [
 ]
 
 [[package]]
+name = "tokenizers"
+version = "0.22.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "huggingface-hub" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/73/6f/f80cfef4a312e1fb34baf7d85c72d4411afde10978d4657f8cdd811d3ccc/tokenizers-0.22.2.tar.gz", hash = "sha256:473b83b915e547aa366d1eee11806deaf419e17be16310ac0a14077f1e28f917", size = 372115, upload-time = "2026-01-05T10:45:15.988Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/92/97/5dbfabf04c7e348e655e907ed27913e03db0923abb5dfdd120d7b25630e1/tokenizers-0.22.2-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:544dd704ae7238755d790de45ba8da072e9af3eea688f698b137915ae959281c", size = 3100275, upload-time = "2026-01-05T10:41:02.158Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/47/174dca0502ef88b28f1c9e06b73ce33500eedfac7a7692108aec220464e7/tokenizers-0.22.2-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:1e418a55456beedca4621dbab65a318981467a2b188e982a23e117f115ce5001", size = 2981472, upload-time = "2026-01-05T10:41:00.276Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/84/7990e799f1309a8b87af6b948f31edaa12a3ed22d11b352eaf4f4b2e5753/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2249487018adec45d6e3554c71d46eb39fa8ea67156c640f7513eb26f318cec7", size = 3290736, upload-time = "2026-01-05T10:40:32.165Z" },
+    { url = "https://files.pythonhosted.org/packages/78/59/09d0d9ba94dcd5f4f1368d4858d24546b4bdc0231c2354aa31d6199f0399/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:25b85325d0815e86e0bac263506dd114578953b7b53d7de09a6485e4a160a7dd", size = 3168835, upload-time = "2026-01-05T10:40:38.847Z" },
+    { url = "https://files.pythonhosted.org/packages/47/50/b3ebb4243e7160bda8d34b731e54dd8ab8b133e50775872e7a434e524c28/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:bfb88f22a209ff7b40a576d5324bf8286b519d7358663db21d6246fb17eea2d5", size = 3521673, upload-time = "2026-01-05T10:40:56.614Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/fa/89f4cb9e08df770b57adb96f8cbb7e22695a4cb6c2bd5f0c4f0ebcf33b66/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1c774b1276f71e1ef716e5486f21e76333464f47bece56bbd554485982a9e03e", size = 3724818, upload-time = "2026-01-05T10:40:44.507Z" },
+    { url = "https://files.pythonhosted.org/packages/64/04/ca2363f0bfbe3b3d36e95bf67e56a4c88c8e3362b658e616d1ac185d47f2/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:df6c4265b289083bf710dff49bc51ef252f9d5be33a45ee2bed151114a56207b", size = 3379195, upload-time = "2026-01-05T10:40:51.139Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/76/932be4b50ef6ccedf9d3c6639b056a967a86258c6d9200643f01269211ca/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:369cc9fc8cc10cb24143873a0d95438bb8ee257bb80c71989e3ee290e8d72c67", size = 3274982, upload-time = "2026-01-05T10:40:58.331Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/28/5f9f5a4cc211b69e89420980e483831bcc29dade307955cc9dc858a40f01/tokenizers-0.22.2-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:29c30b83d8dcd061078b05ae0cb94d3c710555fbb44861139f9f83dcca3dc3e4", size = 9478245, upload-time = "2026-01-05T10:41:04.053Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/fb/66e2da4704d6aadebf8cb39f1d6d1957df667ab24cff2326b77cda0dcb85/tokenizers-0.22.2-cp39-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:37ae80a28c1d3265bb1f22464c856bd23c02a05bb211e56d0c5301a435be6c1a", size = 9560069, upload-time = "2026-01-05T10:45:10.673Z" },
+    { url = "https://files.pythonhosted.org/packages/16/04/fed398b05caa87ce9b1a1bb5166645e38196081b225059a6edaff6440fac/tokenizers-0.22.2-cp39-abi3-musllinux_1_2_i686.whl", hash = "sha256:791135ee325f2336f498590eb2f11dc5c295232f288e75c99a36c5dbce63088a", size = 9899263, upload-time = "2026-01-05T10:45:12.559Z" },
+    { url = "https://files.pythonhosted.org/packages/05/a1/d62dfe7376beaaf1394917e0f8e93ee5f67fea8fcf4107501db35996586b/tokenizers-0.22.2-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:38337540fbbddff8e999d59970f3c6f35a82de10053206a7562f1ea02d046fa5", size = 10033429, upload-time = "2026-01-05T10:45:14.333Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/18/a545c4ea42af3df6effd7d13d250ba77a0a86fb20393143bbb9a92e434d4/tokenizers-0.22.2-cp39-abi3-win32.whl", hash = "sha256:a6bf3f88c554a2b653af81f3204491c818ae2ac6fbc09e76ef4773351292bc92", size = 2502363, upload-time = "2026-01-05T10:45:20.593Z" },
+    { url = "https://files.pythonhosted.org/packages/65/71/0670843133a43d43070abeb1949abfdef12a86d490bea9cd9e18e37c5ff7/tokenizers-0.22.2-cp39-abi3-win_amd64.whl", hash = "sha256:c9ea31edff2968b44a88f97d784c2f16dc0729b8b143ed004699ebca91f05c48", size = 2747786, upload-time = "2026-01-05T10:45:18.411Z" },
+    { url = "https://files.pythonhosted.org/packages/72/f4/0de46cfa12cdcbcd464cc59fde36912af405696f687e53a091fb432f694c/tokenizers-0.22.2-cp39-abi3-win_arm64.whl", hash = "sha256:9ce725d22864a1e965217204946f830c37876eee3b2ba6fc6255e8e903d5fcbc", size = 2612133, upload-time = "2026-01-05T10:45:17.232Z" },
+]
+
+[[package]]
 name = "tomlkit"
 version = "0.13.3"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/cc/18/0bbf3884e9eaa38819ebe46a7bd25dcd56b67434402b66a58c4b8e552575/tomlkit-0.13.3.tar.gz", hash = "sha256:430cf247ee57df2b94ee3fbe588e71d362a941ebb545dec29b53961d61add2a1", size = 185207, upload-time = "2025-06-05T07:13:44.947Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/bd/75/8539d011f6be8e29f339c42e633aae3cb73bffa95dd0f9adec09b9c58e85/tomlkit-0.13.3-py3-none-any.whl", hash = "sha256:c89c649d79ee40629a9fda55f8ace8c6a1b42deb912b2a8fd8d942ddadb606b0", size = 38901, upload-time = "2025-06-05T07:13:43.546Z" },
+]
+
+[[package]]
+name = "torch"
+version = "2.12.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cuda-bindings", marker = "sys_platform == 'linux'" },
+    { name = "cuda-toolkit", extra = ["cudart", "cufft", "cufile", "cupti", "curand", "cusolver", "cusparse", "nvjitlink", "nvrtc", "nvtx"], marker = "sys_platform == 'linux'" },
+    { name = "filelock" },
+    { name = "fsspec" },
+    { name = "jinja2" },
+    { name = "networkx" },
+    { name = "nvidia-cublas", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cudnn-cu13", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cusparselt-cu13", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-nccl-cu13", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-nvshmem-cu13", marker = "sys_platform == 'linux'" },
+    { name = "setuptools" },
+    { name = "sympy" },
+    { name = "triton", marker = "sys_platform == 'linux'" },
+    { name = "typing-extensions" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/62/131124fb95df03811b8260d1d43dcc5ee85ea1a344b964613d7efe77fb08/torch-2.12.0-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:10802fd383bbfed646212e765a72c37d2185205d4f26eb197a254e8ac7ddcb25", size = 87990344, upload-time = "2026-05-13T14:55:42.154Z" },
+    { url = "https://files.pythonhosted.org/packages/12/9c/dda0dbd547dc549839824135f223792fd0e725f28ed0715dda366b7acaa2/torch-2.12.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:c12592630aef72feaf18bd3f197ef587bbfa21131b31c38b23ab2e55fce92e36", size = 426362932, upload-time = "2026-05-13T14:54:15.295Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/d2/a7dd5a3f9bdaa7842124e8e2359202b317c48d47d2fc5816fafdf2049adb/torch-2.12.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:415c1b8d0412f67551c8e89a2daca0fb3e56694af0281ba155eaa9da481f58b4", size = 532170085, upload-time = "2026-05-13T14:55:20.788Z" },
+    { url = "https://files.pythonhosted.org/packages/12/1b/a61ce2004f9ab0ea8964a6e6168133a127795667639e2ff4f8f2bdb16a65/torch-2.12.0-cp311-cp311-win_amd64.whl", hash = "sha256:dd37188ea325042cb1f6cafa56822b11ada2520c04791a52629b0af25bdfbfd9", size = 122953128, upload-time = "2026-05-13T14:54:52.744Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/bb/285d643f254731294c9b595a007eac39db4600a98682d7bca688f42ca164/torch-2.12.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:b41339df93d491435e790ff8bcbae1c0ce777175889bfd1281d119862793e6a2", size = 88010197, upload-time = "2026-05-13T14:55:35.414Z" },
+    { url = "https://files.pythonhosted.org/packages/79/81/76debf1db1343bd929bbb5d74c89fb437c2ed88eb144712557e7bd3eea45/torch-2.12.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:8fbef9f108a863e7722a73740998967e3b074742a834fc5be3a535a2befa7057", size = 426376751, upload-time = "2026-05-13T14:55:03.353Z" },
+    { url = "https://files.pythonhosted.org/packages/de/f0/80026028b603c4650ff270fc3785bdef4bd6738765a9cc5a0f5a637d65a2/torch-2.12.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:4b4f64c2c2b11f7510d93dd6412b87025ff6eddd6bb61c3b5a3d892ea20c4756", size = 532261691, upload-time = "2026-05-13T14:52:54.453Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/c2/64b06cbb7830fb3cd9be13e1158b31a3f36b68e6a209105ee3c9d9480be0/torch-2.12.0-cp312-cp312-win_amd64.whl", hash = "sha256:8b958caff4a14d3a3b0b2dfc6a378f64dda9728a9dad28c08a0db9ce4dafb549", size = 122988114, upload-time = "2026-05-13T14:54:42.153Z" },
+    { url = "https://files.pythonhosted.org/packages/86/ca/01896c80ba921676aa45886b2c5b8d774912de2a1f719de48169c6f755cd/torch-2.12.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:90dd587a5f61bfe1307148b581e2084fc5bc4a06e2b90a20e9a36b81087ff16b", size = 88009511, upload-time = "2026-05-13T14:54:47.411Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/04/52bdaf4787eab6ac7d7f5851dff934e4def0bc8ead9c8fd2b69b3e529699/torch-2.12.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:864392c73b7654f4d2b3ae712f607937d0dbb1101c4555fbb41848106b297f39", size = 426383231, upload-time = "2026-05-13T14:53:32.129Z" },
+    { url = "https://files.pythonhosted.org/packages/49/8a/94bdecd13f5aaa90d45920b89789d9fe7c6f4af8c3cdd7ce01fcb59908fc/torch-2.12.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:5d6b560dfa7d56291c07d615c3bb73e8d9943d9b6d87f76cd0d9d570c4797fa6", size = 532269288, upload-time = "2026-05-13T14:53:49.423Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/2f/bdbaaa267de519ef1b73054bf590d8c93c37a266c9a4e24a01bd38b6918f/torch-2.12.0-cp313-cp313-win_amd64.whl", hash = "sha256:3fee918902090ade827643e758e98363278815de583c75d111fdd665ebffde9f", size = 122987706, upload-time = "2026-05-13T14:54:00.335Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/ad/e95e822f3538171e22640a7fbe839a1fdb666600bf6487025de2ff03b11a/torch-2.12.0-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:10ee1448a9f304d3b987eb4656f664ba6e4d7b410ca7a5a7c642199777a2cf88", size = 88319556, upload-time = "2026-05-13T14:54:05.574Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/07/055d06d985b445d67422d25b033c11cf55bbb81785d4c4e68e28bca5820e/torch-2.12.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:af68dbf403439cae9ceaeaaf92f8352b460787dcd27b92aa05c40dd4a19c0f1e", size = 426397656, upload-time = "2026-05-13T14:52:38.84Z" },
+    { url = "https://files.pythonhosted.org/packages/43/94/b0b4fdc3014122e0a7302fb90086d352aa48f2576f0b252561ebb38c01a8/torch-2.12.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:a6a2eebb237d3b1d9ad3b378e86d9b9e0782afdea8b1e0eba6a13646b9b49c07", size = 532183124, upload-time = "2026-05-13T14:53:16.178Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/c8/052405e6ad05d3237bfe5a4df78f917773956f8e17813a2d44c059068b74/torch-2.12.0-cp313-cp313t-win_amd64.whl", hash = "sha256:2140e373e9a51a3e22ef62e8d14366d0b470d18f0adf19fdc757368077133a34", size = 123232462, upload-time = "2026-05-13T14:52:27.26Z" },
 ]
 
 [[package]]
@@ -3273,6 +3651,28 @@ wheels = [
 ]
 
 [[package]]
+name = "transformers"
+version = "4.57.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "filelock" },
+    { name = "huggingface-hub" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12' and sys_platform == 'win32'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' or sys_platform != 'win32'" },
+    { name = "packaging" },
+    { name = "pyyaml" },
+    { name = "regex" },
+    { name = "requests" },
+    { name = "safetensors" },
+    { name = "tokenizers" },
+    { name = "tqdm" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c4/35/67252acc1b929dc88b6602e8c4a982e64f31e733b804c14bc24b47da35e6/transformers-4.57.6.tar.gz", hash = "sha256:55e44126ece9dc0a291521b7e5492b572e6ef2766338a610b9ab5afbb70689d3", size = 10134912, upload-time = "2026-01-16T10:38:39.284Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/b8/e484ef633af3887baeeb4b6ad12743363af7cce68ae51e938e00aaa0529d/transformers-4.57.6-py3-none-any.whl", hash = "sha256:4c9e9de11333ddfe5114bc872c9f370509198acf0b87a832a0ab9458e2bd0550", size = 11993498, upload-time = "2026-01-16T10:38:31.289Z" },
+]
+
+[[package]]
 name = "triad"
 version = "1.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3287,6 +3687,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/71/28/33e3ffaa73264460e2b0ffae3f897e42e3b1b9245578851d714b44d088fc/triad-1.0.0.tar.gz", hash = "sha256:0bbaf627dfdee8fa05bafe02d87da03460892abd666944da048de8a467e1519d", size = 54185, upload-time = "2025-10-31T06:03:06.709Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1f/a0/8dd7b5b45b96f30a29382b8d7bcd473cfe5573716ad1f3be760963d8f874/triad-1.0.0-py3-none-any.whl", hash = "sha256:0d9b638541e26c24ef6ad8c8f29b5df92eaa436f54cfd02ae1c48b4b0acd6e92", size = 59955, upload-time = "2025-10-31T06:03:05.303Z" },
+]
+
+[[package]]
+name = "triton"
+version = "3.7.0"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b8/c1/5d842314bb6c78442cc60437928781701c6050b8d479bc2a1aed691d37ca/triton-3.7.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a9e71fc392675fac364e0ecf4ef3f76f85b7f5433a16f4c3c5fe5f05a52c85fe", size = 188480277, upload-time = "2026-05-07T19:05:03.231Z" },
+    { url = "https://files.pythonhosted.org/packages/13/31/8315ea5f8dd18e60970b3022e3a8b93fd37e0b784fbbef86e10c8e6e5ca1/triton-3.7.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:22bacffce443f54593dd20f05294d5a40622e0ea9ab632816f87154504356221", size = 201415942, upload-time = "2026-05-07T18:46:06.479Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/13/ec05adfcd87311d532ba61e3af143e8be59fcd26675884c4682841406a20/triton-3.7.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a4bf49b00a7a377a68a6da603a876e797614e6455a80e9021669c476a953ad9a", size = 188505104, upload-time = "2026-05-07T19:05:09.843Z" },
+    { url = "https://files.pythonhosted.org/packages/62/7b/468a576e35beef1426e0828e28e9ba9e65f5474d496f16ee126c15646324/triton-3.7.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8f111161d49bf903c0eaedde3962353a3d841c08a836839b7cc1025b8426efcf", size = 201457567, upload-time = "2026-05-07T18:46:13.505Z" },
+    { url = "https://files.pythonhosted.org/packages/01/e1/a59a583de59b8f62c495d67c80ee3ea97d09e91ac80c4c6e76456ed8d8ac/triton-3.7.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:abdf6beaa89b1bcfb9a43cd990536ce66091a997841a4814b260b7bee4c88c3c", size = 188503209, upload-time = "2026-05-07T19:05:17.935Z" },
+    { url = "https://files.pythonhosted.org/packages/30/b1/b7507bb9815d403927c8dd51d4158ed2e11751a92dbc118a044f247b6848/triton-3.7.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a35d7afe3f3f058e7ec49fcce09794049e0ffc5c59019ac25ec3413741b8c4e7", size = 201453566, upload-time = "2026-05-07T18:46:20.427Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/8f/0bea7a6a0c989315c9135a1d7fb37e41905cfb3a17cbc1f10044ebd4cc3a/triton-3.7.0-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cc1d61c172d257db80ddf42595131fb196ad2e9bdd751e90fe2ef13531734e8b", size = 188612899, upload-time = "2026-05-07T19:05:24.955Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/02/d96f57828d0912aec733b9bc7e0e7dbfd2c6f079a8fa433ac25cb93d1a30/triton-3.7.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:70fb9bbdc9f400afc54bbf6eb2670af28829a6ae3996863317964783141daf56", size = 201553816, upload-time = "2026-05-07T18:46:27.49Z" },
 ]
 
 [[package]]
@@ -3331,6 +3746,10 @@ decomposition = [
 forecasting = [
     { name = "statsforecast" },
 ]
+foundation = [
+    { name = "chronos-forecasting" },
+    { name = "torch" },
+]
 patterns = [
     { name = "ruptures" },
     { name = "stumpy" },
@@ -3368,6 +3787,7 @@ requires-dist = [
     { name = "aeon", marker = "extra == 'all'", specifier = ">=1.3.0" },
     { name = "aeon", marker = "extra == 'classification'", specifier = ">=1.3.0" },
     { name = "aeon", marker = "extra == 'recommended'", specifier = ">=1.3.0" },
+    { name = "chronos-forecasting", marker = "extra == 'foundation'", specifier = ">=2.0,<3" },
     { name = "gradio", marker = "extra == 'all'", specifier = ">=6.0" },
     { name = "gradio", marker = "extra == 'recommended'", specifier = ">=6.0" },
     { name = "gradio", marker = "extra == 'ui'", specifier = ">=6.0" },
@@ -3404,8 +3824,9 @@ requires-dist = [
     { name = "statsmodels", marker = "extra == 'recommended'", specifier = ">=0.14.2" },
     { name = "stumpy", marker = "extra == 'all'", specifier = ">=1.13.0" },
     { name = "stumpy", marker = "extra == 'patterns'", specifier = ">=1.13.0" },
+    { name = "torch", marker = "extra == 'foundation'", specifier = ">=2.0" },
 ]
-provides-extras = ["viz", "ui", "agents", "decomposition", "forecasting", "patterns", "classification", "recommended", "all"]
+provides-extras = ["viz", "ui", "agents", "decomposition", "forecasting", "patterns", "classification", "foundation", "recommended", "all"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -3429,19 +3850,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/8f/28/7c85c8032b91dbe79725b6f17d2fffc595dff06a35c7a30a37bef73a1ab4/typer-0.20.0.tar.gz", hash = "sha256:1aaf6494031793e4876fb0bacfa6a912b551cf43c1e63c800df8b1a866720c37", size = 106492, upload-time = "2025-10-20T17:03:49.445Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/78/64/7713ffe4b5983314e9d436a90d5bd4f63b6054e2aca783a3cfc44cb95bbf/typer-0.20.0-py3-none-any.whl", hash = "sha256:5b463df6793ec1dca6213a3cf4c0f03bc6e322ac5e16e13ddd622a889489784a", size = 47028, upload-time = "2025-10-20T17:03:47.617Z" },
-]
-
-[[package]]
-name = "typer-slim"
-version = "0.20.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "click" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/8e/45/81b94a52caed434b94da65729c03ad0fb7665fab0f7db9ee54c94e541403/typer_slim-0.20.0.tar.gz", hash = "sha256:9fc6607b3c6c20f5c33ea9590cbeb17848667c51feee27d9e314a579ab07d1a3", size = 106561, upload-time = "2025-10-20T17:03:46.642Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/5e/dd/5cbf31f402f1cc0ab087c94d4669cfa55bd1e818688b910631e131d74e75/typer_slim-0.20.0-py3-none-any.whl", hash = "sha256:f42a9b7571a12b97dddf364745d29f12221865acef7a2680065f9bb29c7dc89d", size = 47087, upload-time = "2025-10-20T17:03:44.546Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -3725,6 +3725,7 @@ agents = [
 ]
 all = [
     { name = "aeon" },
+    { name = "chronos-forecasting" },
     { name = "gradio" },
     { name = "langchain" },
     { name = "langchain-core" },
@@ -3735,6 +3736,7 @@ all = [
     { name = "statsforecast" },
     { name = "statsmodels" },
     { name = "stumpy" },
+    { name = "torch" },
 ]
 classification = [
     { name = "aeon" },
@@ -3787,6 +3789,7 @@ requires-dist = [
     { name = "aeon", marker = "extra == 'all'", specifier = ">=1.3.0" },
     { name = "aeon", marker = "extra == 'classification'", specifier = ">=1.3.0" },
     { name = "aeon", marker = "extra == 'recommended'", specifier = ">=1.3.0" },
+    { name = "chronos-forecasting", marker = "extra == 'all'", specifier = ">=2.0,<3" },
     { name = "chronos-forecasting", marker = "extra == 'foundation'", specifier = ">=2.0,<3" },
     { name = "gradio", marker = "extra == 'all'", specifier = ">=6.0" },
     { name = "gradio", marker = "extra == 'recommended'", specifier = ">=6.0" },
@@ -3824,6 +3827,7 @@ requires-dist = [
     { name = "statsmodels", marker = "extra == 'recommended'", specifier = ">=0.14.2" },
     { name = "stumpy", marker = "extra == 'all'", specifier = ">=1.13.0" },
     { name = "stumpy", marker = "extra == 'patterns'", specifier = ">=1.13.0" },
+    { name = "torch", marker = "extra == 'all'", specifier = ">=2.0" },
     { name = "torch", marker = "extra == 'foundation'", specifier = ">=2.0" },
 ]
 provides-extras = ["viz", "ui", "agents", "decomposition", "forecasting", "patterns", "classification", "foundation", "recommended", "all"]


### PR DESCRIPTION
## Summary
- Surface deep-agent runtime/fallback status consistently across CLI JSON and UI warnings.
- Add the scoped `foundation-chronos-smoke` loop with a `ts-agents[foundation]` optional extra and backend install/preflight handling.
- Add external GIFT-Eval/TimeCopilot context artifacts and update docs to frame ts-agents as a workflow/artifact/sandbox contract layer, not a model hub.

## Verification
- `uv run ruff check ts_agents/agents/deep/orchestrator.py ts_agents/autoresearch/runner.py ts_agents/autoresearch/registry.py ts_agents/autoresearch/executor.py ts_agents/cli/main.py ts_agents/ui/components/chat.py tests/agents/test_deep_agent.py tests/cli/test_autoresearch.py tests/cli/test_params.py tests/test_package_metadata.py`
- `uv run python -m pytest -q tests/cli/test_autoresearch.py tests/agents/test_deep_agent.py tests/cli/test_params.py tests/test_package_metadata.py` (113 passed)
- `uv run python -m pytest -q` (505 passed, 3 warnings)
- `uv run ts-agents autoresearch run foundation-chronos-smoke --dry-run --skip-plots --output-dir /tmp/ts_agents_chronos_review_dry --overwrite --json`
- `uv run ts-agents autoresearch run foundation-chronos-smoke --output-dir /tmp/ts_agents_chronos_review_deps --overwrite --json` (expected dependency_error without `ts-agents[foundation]`)

Closes #92